### PR TITLE
Restore increased gunicorn timeout

### DIFF
--- a/conf/salt/project/web/gunicorn.conf
+++ b/conf/salt/project/web/gunicorn.conf
@@ -1,0 +1,15 @@
+[program:{{ pillar['project_name'] }}-server]
+command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=120
+user={{ pillar['project_name'] }}
+directory={{ directory }}
+autostart=true
+autorestart=true
+stopasgroup=false
+killasgroup=true
+stopwaitsecs=60
+# Supervisor 3.x:
+stdout_logfile=syslog
+redirect_stderr=true
+# Supervisor 4.0:
+#stdout_syslog=true
+#stderr_syslog=true


### PR DESCRIPTION
Increase gunicorn timeout to 120 seconds so workers have time to return API calls against large agencies before being killed prematurely. This is currently on ``master``, but got overridden while cleaning up ``conf/`` on dev while upgrading margarita. I deployed this branch to staging to test and now all graphs on large agencies, like Durham, load properly.