### PR TITLE
ODPM-27 - MD data import improvements

### DIFF
--- a/md/admin.py
+++ b/md/admin.py
@@ -1,3 +1,9 @@
 from django.contrib import admin
+from md.models import Agency
 
-# Register your models here.
+
+class AgencyAdmin(admin.ModelAdmin):
+    pass
+
+
+admin.site.register(Agency, AgencyAdmin)

--- a/md/data/copy.sql
+++ b/md/data/copy.sql
@@ -35,6 +35,11 @@ WHERE
 
 ANALYZE;
 
+ALTER TABLE "public"."md_stop" ADD CONSTRAINT "md_stop_pkey" PRIMARY KEY (stop_id);
+ALTER TABLE "public"."md_agency" ADD CONSTRAINT "md_agency_pkey" PRIMARY KEY (id);
+ALTER TABLE "public"."django_migrations" ADD CONSTRAINT "django_migrations_pkey" PRIMARY KEY (id);
+ALTER TABLE "public"."md_stop" ADD CONSTRAINT "md_stop_age_check" CHECK ((age >= 0));
+ALTER TABLE "public"."md_stop" ADD CONSTRAINT "md_stop_agency_id_39a3e53ab65af866_fk_md_agency_id" FOREIGN KEY (agency_id) REFERENCES md_agency(id) DEFERRABLE INITIALLY DEFERRED;
 CREATE INDEX md_stop_169fc544 ON md_stop USING btree (agency_id);
 
 ANALYZE;

--- a/md/data/importer.py
+++ b/md/data/importer.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+import math
 import os
 import re
 
@@ -31,6 +33,8 @@ ETHNICITY_TO_CODE = {
 }
 
 STOP_REASON_re = re.compile(r'^ *(\d+) *- *(\d+) *\(.*\) *$')
+
+DOB_re = re.compile(r'^(\d\d?)/(\d\d?)/(\d\d?)$')
 
 MD_COLUMNS_TO_DROP = (
     'WHATSEARCHED', 'STOPOUTCOME', 'CRIME_CHARGED',
@@ -91,14 +95,28 @@ def fix_TIME_OF_STOP(s):
 
 
 def compute_AGE(row):
+    dob = row['DOB']
     stop_date = row['date']
-    dob = row['DOB_as_dt']
-    if pd.isnull(dob) or dob > stop_date:
-        logger.info('Bad DOB vs. stop date: "%s", "%s"', dob, stop_date)
-        return 0
+
+    m = DOB_re.match(dob)
+    if not m:
+        age = 0
     else:
+        dob_year = int(m.group(3))
+        stop_date_year = stop_date.year
+        stop_date_year_of_century = stop_date_year % 100
+        stop_date_century = int(math.floor(stop_date_year / 100.0)) * 100
+
+        if dob_year >= stop_date_year_of_century:
+            dob_year += (stop_date_century - 100)
+        else:
+            dob_year += stop_date_century
+
+        dob = datetime.datetime(dob_year, int(m.group(1)), int(m.group(2)))
         delta = stop_date - dob
-        return int(delta.days / 365.25)
+        age = int(delta.days / 365.25)
+
+    return age
 
 
 def load_xls(xls_path):
@@ -123,9 +141,7 @@ def add_date_column(stops):
 
 
 def add_age_column(stops):
-    stops['DOB_as_dt'] = pd.to_datetime(stops.DOB)
     stops['computed_AGE'] = stops.apply(compute_AGE, axis=1)
-    stops.drop(['DOB_as_dt'], axis=1, inplace=True)
 
 
 def process_raw_data(stops):

--- a/md/data/importer.py
+++ b/md/data/importer.py
@@ -6,8 +6,10 @@ import re
 
 import pandas as pd
 
+from django.db import connections
 from django.conf import settings
 
+from tsdata.sql import drop_constraints_and_indexes
 from tsdata.util import (call, download_and_unzip_data, get_csv_path,
      get_datafile_path, line_count)
 
@@ -186,6 +188,8 @@ def run(url, destination=None, download=True):
         logger.info("{} exists, skipping XLS->CSV conversion".format(csv_path))
     csv_count = line_count(csv_path)
     logger.debug('Rows: {}'.format(csv_count))
+    # drop constraints/indexes
+    drop_constraints_and_indexes(connections['traffic_stops_md'].cursor())
     # use COPY to load CSV files as quickly as possible
     copy_from(csv_path)
 

--- a/md/management/commands/md_constraints_sql.py
+++ b/md/management/commands/md_constraints_sql.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+from django.db import connections
+from tsdata.sql import get_add_constraints_and_indexes
+
+
+class Command(BaseCommand):
+    """Inspect and print current MD database constraints and indexes"""
+
+    def handle(self, *args, **options):
+        cursor = connections['traffic_stops_md'].cursor()
+        print(get_add_constraints_and_indexes(cursor))

--- a/md/tests/test_normalization.py
+++ b/md/tests/test_normalization.py
@@ -3,8 +3,9 @@
 from django.test import TestCase
 import pandas as pd
 
-from md.data.importer import (add_age_column, add_date_column, fix_ETHNICITY,
-    fix_GENDER, fix_SEIZED, fix_STOP_REASON, fix_TIME_OF_STOP)
+from md.data.importer import (add_age_column, add_date_column,
+    fix_ETHNICITY, fix_GENDER, fix_SEIZED, fix_STOP_REASON,
+    fix_TIME_OF_STOP)
 
 
 class TestFieldNormalization(TestCase):
@@ -96,17 +97,18 @@ class TestFieldNormalization(TestCase):
 
     def test_computed_age(self):
         stops = pd.DataFrame({
-            'STOPDATE': ['03/04/13', '12/31/12', '1/1/15'],
-            'TIME_OF_STOP': ['00:21', '11:50', '11:50'],
-            'DOB': ['05/27/89', '', '1/1/20']
+            'STOPDATE': [
+                '03/04/13', '12/31/12', '1/1/15'
+            ],
+            'TIME_OF_STOP': [
+                '00:21', '11:50', '11:50'
+            ],
+            'DOB': [
+                '05/27/89', '', '01/01/20'
+            ]
         })
         add_date_column(stops)
         add_age_column(stops)
         self.assertEqual(stops.computed_AGE[0], 23)
         self.assertEqual(stops.computed_AGE[1], 0)
-        # Bug in age computation
-        # Fix in ODPM-27
-        # Conversion to datetime should assume a two-digit year
-        # greater than the current two-digit year is from the
-        # previous century.
-        # NO!  self.assertEqual(stops.computed_AGE[2], 0)
+        self.assertEqual(stops.computed_AGE[2], 95)

--- a/tsdata/sql.py
+++ b/tsdata/sql.py
@@ -70,7 +70,7 @@ SELECT 'ALTER TABLE "'||nspname||'"."'||relname||'" ADD CONSTRAINT "'||conname||
 FROM pg_constraint
 INNER JOIN pg_class ON conrelid=pg_class.oid
 INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
-WHERE relname LIKE 'nc_%'
+WHERE relname NOT LIKE 'pg_%'
 ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END DESC,contype DESC,nspname DESC,relname DESC,conname DESC;
 """  # noqa
 

--- a/tsdata/sql.py
+++ b/tsdata/sql.py
@@ -31,7 +31,10 @@ def get_sql_statements(cursor, select_sql):
     Simple wrapper function used to execute a SQL query that returns a
     list of SQL commands to be run later.
     """
-    cursor.execute(select_sql)
+    # Explicitly pass None for params to avoid different behavior when
+    # running through Django Debug Toolbar (it defaults params to (),
+    # Django expects None for no params).
+    cursor.execute(select_sql, params=None)
     sql = ''
     for row in cursor.fetchall():
         sql += '{}\n'.format(row[0])


### PR DESCRIPTION
Handled in this pull request:

- Add minimal admin support, matching that for NC
- Extract support for performing the import in a transaction from the NC code, add to MD code
- Verify that reloading MD data on a task will work (to support reloading new data into the same model on staging and production)
- Handle two-digit years for DOB greater than the current two-digit year. (The pandas datetime conversion didn't automatically make sense of two-digit years the way we want.)

This was previously planned but not implemented:

- "Add at least some test of the model. (NC has tests for API and other code that uses the model; we don't have such code yet. It seems like a good idea to have some test Real Soon.)"
A lot of tests were added in the original pull request, and I can't identify any helpful model tests at this point.

- "Axe current MD migrations completely and start from zero (db will always be dropped before loading data in a new format anyway), which allows minor simplifications for the model (some default= and null=True field settings)"
We/Colin decided not to do this.
