### PR TITLE
ODPM-53: Style and structure changes to prevent tabs wrapping

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -307,9 +307,14 @@ body#state {
   .nav-tabs {
     margin-top: 1rem;
 
+    .flex-layout();
+    .flex-direction(row);
+    .flex-wrap(nowrap);
+    .align-items(flex-end);
+
     > li {
       > a {
-        > h2 {
+        > h4 {
           margin: 0;
         }
       }

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -48,10 +48,10 @@
       <div class="col-md-5 col-sm-6" id="explore-data" data-toggle="tabslet">
         <ul class="nav nav-tabs" data-role="tablist">
           <li role="presentation" class="active">
-            <a href="#agencies" aria-controls="agencies" role="tab" data-toggle="tab"><h2 class="active">Agencies</h2></a>
+            <a href="#agencies" aria-controls="agencies" role="tab" data-toggle="tab"><h4 class="active">Agencies</h4></a>
           </li>
           <li role="presentation">
-            <a href="#find-a-stop" aria-controls="find-a-stop" role="tab" data-toggle="tab"><h2>Find a Stop</h2></a>
+            <a href="#find-a-stop" aria-controls="find-a-stop" role="tab" data-toggle="tab"><h4>Find a Stop</h4></a>
           </li>
         </ul>
 


### PR DESCRIPTION
In addition to using flex layout to pin tab contents to the bottom of
the available space, this reduces them from `h2` to `h4` to make them more
compact and consistent with the headers below them.