### PR TITLE
Changing color and hover behavior of tabs

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -312,6 +312,17 @@ body#state {
         > h2 {
           margin: 0;
         }
+
+        &:hover {
+          background-color: #e3e3e3;
+        }
+      }
+
+      &.active {
+        > a {
+          background-color: transparent;
+          border-bottom-color: #efefef;
+        }
       }
     }
   }

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -42,6 +42,29 @@ h1, h2, h3, h4, h5 {
   color: @brand-primary;
 }
 
+.nav-tabs {
+  margin-top: 1rem;
+
+  > li {
+    > a {
+      > h2 {
+        margin: 0;
+      }
+
+      &:hover {
+        background-color: #e3e3e3;
+      }
+    }
+
+    &.active {
+      > a {
+        background-color: transparent !important;
+        border-bottom-color: #efefef !important;
+      }
+    }
+  }
+}
+
 /* Sticky footer styles
 -------------------------------------------------- */
 
@@ -302,29 +325,6 @@ body#state {
   }
   #elevator {
     font-size: 110%;
-  }
-
-  .nav-tabs {
-    margin-top: 1rem;
-
-    > li {
-      > a {
-        > h2 {
-          margin: 0;
-        }
-
-        &:hover {
-          background-color: #e3e3e3;
-        }
-      }
-
-      &.active {
-        > a {
-          background-color: transparent;
-          border-bottom-color: #efefef;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
This makes two changes to tabs (both on state homepage and agency detail page):

* Their background color is now always grey, never white, even when they're active.
* ... except their background color becomes a slightly contrasting shade of grey when you hover the cursor over an inactive tab.