### PR TITLE
ODPM-55: Reformatting pie chart hover labels

### DIFF
--- a/traffic_stops/static/js/app/states/md/Stops.js
+++ b/traffic_stops/static/js/app/states/md/Stops.js
@@ -115,7 +115,10 @@ export var StopRatioDonut = VisualBase.extend({
       .labelType("percent")
       .donutRatio(0.35)
       .labelThreshold(0.05)
-      .donut(true);
+      .donut(true)
+      .tooltipContent((key, y, e, graph) => (
+        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d\d/, '') }</p>`
+      ));
   },
   drawStartup: function(){
 

--- a/traffic_stops/static/js/app/states/md/Stops.js
+++ b/traffic_stops/static/js/app/states/md/Stops.js
@@ -117,7 +117,7 @@ export var StopRatioDonut = VisualBase.extend({
       .labelThreshold(0.05)
       .donut(true)
       .tooltipContent((key, y, e, graph) => (
-        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d\d/, '') }</p>`
+        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d*/, '') }</p>`
       ));
   },
   drawStartup: function(){

--- a/traffic_stops/static/js/app/states/nc/Stops.js
+++ b/traffic_stops/static/js/app/states/nc/Stops.js
@@ -92,7 +92,10 @@ export var StopRatioDonut = VisualBase.extend({
       .labelType("percent")
       .donutRatio(0.35)
       .labelThreshold(0.05)
-      .donut(true);
+      .donut(true)
+      .tooltipContent((key, y, e, graph) => (
+        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d\d/, '') }</p>`
+      ));
   },
   drawStartup: function(){
 

--- a/traffic_stops/static/js/app/states/nc/Stops.js
+++ b/traffic_stops/static/js/app/states/nc/Stops.js
@@ -94,7 +94,7 @@ export var StopRatioDonut = VisualBase.extend({
       .labelThreshold(0.05)
       .donut(true)
       .tooltipContent((key, y, e, graph) => (
-        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d\d/, '') }</p>`
+        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d*/, '') }</p>`
       ));
   },
   drawStartup: function(){

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -361,3 +361,7 @@ body#state {
 .nvd3 .nv-groups path.nv-line {
   stroke-width: 5px;
 }
+
+h3.donut-label {
+  font-size: 16px;
+}


### PR DESCRIPTION
This modifies the `tooltipContent` values for NC and MD stops pie charts to have smaller headers and to display integers.

The `h3` type (which is what the default `tooltipContent` seems to generate) is still used, with a modifying class, because doing otherwise seems to clog up NVD3's basic whitespace styles. Why fight it?