### PR TITLE
ODPM-57: Adding babel-polyfill requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@caktus/flexless": "^0.1.1",
     "babel-core": "^6.10.4",
     "babel-plugin-rewire": "^1.0.0-rc-4",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.1.18",
     "babelify": "^7.2.0",
     "backbone": "1.1.2",

--- a/traffic_stops/static/js/index.js
+++ b/traffic_stops/static/js/index.js
@@ -1,3 +1,4 @@
+require("babel-polyfill");
 window.jQuery = window.$ = require('jquery');
 window.d3 = require('d3');
 var nv = require('nvd3');


### PR DESCRIPTION
The graphs are failing on IE because I used `Object.assign`, which won't work on older browsers without `babel-polyfill`, which I forgot to include.