### PR TITLE
Odpm 54 new allow migrate sig

### DIFF
--- a/nc/tests/test_router.py
+++ b/nc/tests/test_router.py
@@ -1,8 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 
-import nc
-import traffic_stops
 from nc.models import Stop
 from traffic_stops.routers import StateDatasetRouter
 
@@ -31,19 +29,24 @@ class StateDatasetRouterTest(TestCase):
     def test_syncdb_state_model_defaultdb(self):
         """State models should not sync to the default DB"""
         router = StateDatasetRouter()
-        self.assertFalse(router.allow_migrate('default', nc, Stop))
+        self.assertFalse(router.allow_migrate('default', 'nc', Stop))
 
     def test_syncdb_other_model_defaultdb(self):
         """Other models should sync to the default DB"""
         router = StateDatasetRouter()
-        self.assertTrue(router.allow_migrate('default', traffic_stops))
+        self.assertTrue(router.allow_migrate('default', 'auth', User))
 
     def test_syncdb_state_model_statedb(self):
-        """State models should sync to State DBs"""
+        """State models should sync to same State DBs"""
         router = StateDatasetRouter()
-        self.assertTrue(router.allow_migrate('traffic_stops_nc', nc))
+        self.assertTrue(router.allow_migrate('traffic_stops_nc', 'nc', Stop))
+
+    def test_syncdb_other_state_statedb(self):
+        """State models should not sync to other State DBs"""
+        router = StateDatasetRouter()
+        self.assertFalse(router.allow_migrate('traffic_stops_nc', 'md', Stop))
 
     def test_syncdb_other_model_statedb(self):
         """Other models should not sync to State DBs"""
         router = StateDatasetRouter()
-        self.assertFalse(router.allow_migrate('traffic_stops_nc', auth, User))
+        self.assertFalse(router.allow_migrate('traffic_stops_nc', 'auth', User))

--- a/nc/tests/test_router.py
+++ b/nc/tests/test_router.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 
+import nc
+import traffic_stops
 from nc.models import Stop
 from traffic_stops.routers import StateDatasetRouter
 
@@ -29,19 +31,19 @@ class StateDatasetRouterTest(TestCase):
     def test_syncdb_state_model_defaultdb(self):
         """State models should not sync to the default DB"""
         router = StateDatasetRouter()
-        self.assertFalse(router.allow_migrate('default', Stop))
+        self.assertFalse(router.allow_migrate('default', nc, Stop))
 
     def test_syncdb_other_model_defaultdb(self):
         """Other models should sync to the default DB"""
         router = StateDatasetRouter()
-        self.assertTrue(router.allow_migrate('default', User))
+        self.assertTrue(router.allow_migrate('default', traffic_stops))
 
     def test_syncdb_state_model_statedb(self):
         """State models should sync to State DBs"""
         router = StateDatasetRouter()
-        self.assertTrue(router.allow_migrate('traffic_stops_nc', Stop))
+        self.assertTrue(router.allow_migrate('traffic_stops_nc', nc))
 
     def test_syncdb_other_model_statedb(self):
         """Other models should not sync to State DBs"""
         router = StateDatasetRouter()
-        self.assertFalse(router.allow_migrate('traffic_stops_nc', User))
+        self.assertFalse(router.allow_migrate('traffic_stops_nc', auth, User))

--- a/traffic_stops/routers.py
+++ b/traffic_stops/routers.py
@@ -39,8 +39,6 @@ class StateDatasetRouter(object):
         # traffic_stops_nc  traffic_stops_admin False
         # traffic_stops_nc  traffic_stops_nc    True
         #
-        logger.debug('allow_syncdb({}, {}): {} {}'.format(db, app_label,
-                                                          model_name, hints))
         db_state = db[-2:]
         app_is_state = app_label in ('nc', 'md')
         if db_state == app_label:

--- a/traffic_stops/routers.py
+++ b/traffic_stops/routers.py
@@ -45,10 +45,7 @@ class StateDatasetRouter(object):
         state_db = self._db_name_from_label(app_label)
         app_is_state = state_db in settings.DATABASES
         if app_is_state:
-            if db[-2:] == app_label:
-                ret = True
-            else:
-                ret = False
+            ret = db == state_db
         elif db == 'default':
             ret = True
         else:

--- a/traffic_stops/routers.py
+++ b/traffic_stops/routers.py
@@ -31,7 +31,7 @@ class StateDatasetRouter(object):
         logger.debug('db_for_write({}): {}'.format(state_db, name))
         return name
 
-    def allow_migrate(self, db, model):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
         # scenarios:
         #
         # default           traffic_stops_nc    False
@@ -39,16 +39,15 @@ class StateDatasetRouter(object):
         # traffic_stops_nc  traffic_stops_admin False
         # traffic_stops_nc  traffic_stops_nc    True
         #
-        name = self._db_name(model)
-        if db == 'default':
-            if name in settings.DATABASES:
-                ret = False
-            else:
-                ret = True
+        logger.debug('allow_syncdb({}, {}): {} {}'.format(db, app_label, model_name, hints))
+        db_state = db[-2:]
+        app_is_state = app_label in ('nc', 'md')
+        if db_state == app_label:
+            ret = True
+        elif db == 'default' and app_is_state:
+            ret = False
         else:
-            if name in settings.DATABASES and db == name:
-                ret = True
-            else:
-                ret = False
-        logger.debug('allow_syncdb({}, {}): {}'.format(db, model, ret))
+            ret = True
+
+        logger.debug('allow_syncdb({}, {}): {}'.format(db, app_label, model_name, ret))
         return ret

--- a/traffic_stops/routers.py
+++ b/traffic_stops/routers.py
@@ -39,15 +39,20 @@ class StateDatasetRouter(object):
         # traffic_stops_nc  traffic_stops_admin False
         # traffic_stops_nc  traffic_stops_nc    True
         #
-        logger.debug('allow_syncdb({}, {}): {} {}'.format(db, app_label, model_name, hints))
+        logger.debug('allow_syncdb({}, {}): {} {}'.format(db, app_label,
+                                                          model_name, hints))
         db_state = db[-2:]
         app_is_state = app_label in ('nc', 'md')
         if db_state == app_label:
             ret = True
-        elif db == 'default' and app_is_state:
-            ret = False
+        elif db == 'default':
+            if app_is_state:
+                ret = False
+            else:
+                ret = True
         else:
-            ret = True
-
-        logger.debug('allow_syncdb({}, {}): {}'.format(db, app_label, model_name, ret))
+            ret = False
+        logger.debug(
+            'allow_syncdb({}, {}): {} {} {}'.format(db, app_label, model_name,
+                                                    app_label, app_is_state, ret))
         return ret

--- a/traffic_stops/settings/base.py
+++ b/traffic_stops/settings/base.py
@@ -233,7 +233,7 @@ LOGGING = {
         },
         'traffic_stops': {
             'handlers': ['file', 'syslog'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': False,
         },
         'tsdata': {

--- a/traffic_stops/settings/base.py
+++ b/traffic_stops/settings/base.py
@@ -233,7 +233,7 @@ LOGGING = {
         },
         'traffic_stops': {
             'handlers': ['file', 'syslog'],
-            'level': 'INFO',
+            'level': 'DEBUG',
             'propagate': False,
         },
         'tsdata': {


### PR DESCRIPTION
This pr changes the sig for allow_migrate in the router based on this change in Django 1.8 [](https://docs.djangoproject.com/en/1.8/releases/1.8/#deprecated-signature-of-allow-migrate)

It also refactors the logic a little bit and adds a test for the case of trying to apply a migration to the wrong state's db.