### PR TITLE
ODPM-36 officer data

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -240,7 +240,7 @@ code {
   text-shadow: 0 1px 0 rgba(0, 0, 0, .5);
 
   &.agency-detail {
-    padding: 60px 40px 50px 40px;
+    padding: 70px 40px 60px 40px;
   }
 
   h1 {
@@ -252,6 +252,10 @@ code {
   @media (max-width: @screen-sm-min) {
     padding-bottom: 30px;
 
+    &.agency-detail {
+      padding-top: 60px;
+    }
+
     p {
       font-size: 18px;
     }
@@ -261,6 +265,8 @@ code {
     color: white;
     text-shadow: none;
     font-size: 14px;
+    display: inline-block;
+    padding: 10px 0;
   }
 }
 
@@ -377,11 +383,11 @@ body#state {
 ========================================= */
 
 .state-banner.officer {
-  padding-bottom: 10px;
+  padding-bottom: 20px;
 }
 
 h2.officer {
-  margin-top: 10px;
+  margin-top: 5px;
   color: white;
 }
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -432,6 +432,18 @@ nav.graphs-nav {
 
     > li {
       &.active {
+        a {
+          color: @brand-primary;
+          margin: 0 1rem;
+
+          &:first-child {
+            margin-left: 0;
+          }
+
+          &:last-child {
+            margin-right: 0;
+          }
+        }
         > a {
           color: white;
           background-color: @brand-primary;

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -278,12 +278,11 @@ code {
       .title-container {
         margin-bottom: 20px;
         padding: 0 30px;
+        border-bottom: 1px solid white;
       }
 
       h1 {
-        border-bottom: 1px solid white;
         display: inline-block;
-        padding-bottom: 20px;
       }
     }
 }
@@ -376,6 +375,15 @@ body#state {
 
 /* Agency detail page
 ========================================= */
+
+.state-banner.officer {
+  padding-bottom: 10px;
+}
+
+h2.officer {
+  margin-top: 10px;
+  color: white;
+}
 
 .headline {
   padding-left: 3rem;

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -419,7 +419,7 @@ nav.graphs-nav {
     padding: 0;
     margin: 0;
     list-style: none;
-    font-size: 16px;
+    font-size: 18px;
 
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
@@ -431,9 +431,6 @@ nav.graphs-nav {
     .align-items(center);
 
     > li {
-      a {
-        margin-right: 2rem;
-      }
       &.active {
         > a {
           color: white;

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -8,14 +8,21 @@
 
 {% block content-outer %}
 
-<div class="state-banner agency-detail">
+<div class="state-banner agency-detail{% if officer_id %} officer{% endif %}">
   <div class="row vertical-align">
     <div class="col-xs-12">
       <a class="back" href="{% block agency-list-url %}{% endblock %}">◀ Back to "Find An Agency"</a>
     </div>
-    <div class="col-sm-10 col-xs-12 title-container">
-      <h1>{{ object }}{% if officer_id %}: officer {{officer_id}} {% endif %}</h1>
-    </div>
+    {% if officer_id %}
+      <div class="col-sm-10 col-xs-12 title-container">
+        <h1>Data for Officer Alias: {{officer_id}}</h1>
+        <h2 class="officer">{{ object }}</h2>
+      </div>
+    {% else %}
+      <div class="col-sm-10 col-xs-12 title-container">
+        <h1>{{ object }}</h1>
+      </div>
+    {% endif %}
     <div class="col-sm-2 col-xs-12">
       <a class="btn brand" href="{% block search-url %}{% endblock search-url %}">Find a Stop</a>
     </div>

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -32,7 +32,7 @@
 <nav class="graphs-nav" id="graphs-nav">
   <ul class="nav">
     {% block census-link %}{% endblock census-link %}
-    <li><a href="#stop-percentage">Stop Percentage</a></li>
+    <li><a href="#stop-percentage">Traffic Stops</a></li>
     <li><a href="#search-percentage-dept">Departmental Search Rate</a></li>
   </ul>
   {% block race-selector %}{% endblock race-selector %}


### PR DESCRIPTION
Seemingly, dropping in an `officer_id` parameter "just works".

A suitable officer ID can be found by importing the Stop model from `md.models`, `filter`ing by `agency__name` (e.g. `"MSP"`), picking some arbitrary Stop, and getting the `officer_id`. Then you can construct a URL like `http://localhost:8000/md/agency/80/?officer_id=4735`.

As such, this patch just includes stylistic and template nudges to make it match the mockups.