### PR TITLE
ODPM-62: fixing IE graph issues

### DIFF
--- a/traffic_stops/static/js/app/common/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/common/ContrabandHitRate.js
@@ -116,6 +116,8 @@ export const ContrabandHitRateBarBase = VisualBase.extend({
             .datum(this.dataset)
             .attr('width', "100%")
             .attr('height', "100%")
+            .style({ width:  `${this.get('width')}px`
+                   , height: `${this.get('height')}px` })
             .attr('preserveAspectRatio', "xMinYMin")
             .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
             .call(this.chart);

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -128,6 +128,8 @@ export const LikelihoodOfSearchBase = VisualBase.extend({
       .datum(this.dataset)
       .attr('width', "100%")
       .attr('height', "100%")
+      .style({ width:  `${this.get('width')}px`
+             , height: `${this.get('height')}px` })
       .attr('preserveAspectRatio', "xMinYMin")
       .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
       .call(this.chart);

--- a/traffic_stops/static/js/app/common/Stops.js
+++ b/traffic_stops/static/js/app/common/Stops.js
@@ -154,9 +154,11 @@ export const StopRatioDonutBase = VisualBase.extend({
     nv.addGraph(() => {
       d3.select(this.svg[0])
           .datum(data)
-        .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")
+          .style({ width:  `${this.get('width')}px`
+                 , height: `${this.get('height')}px` })
+        .transition().duration(1200)
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);
@@ -217,6 +219,8 @@ export const StopRatioTimeSeriesBase = VisualBase.extend({
           .datum(data)
           .attr('width', "100%")
           .attr('height', "100%")
+          .style({ width:  `${this.get('width')}px`
+                 , height: `${this.get('height')}px` })
           .attr('preserveAspectRatio', "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -55,6 +55,8 @@ var CensusRatioDonut = VisualBase.extend({
         .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")
+          .style({ width:  `${this.get('width')}px`
+                 , height: `${this.get('height')}px` })
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);


### PR DESCRIPTION
Internet Explorer, it appears, doesn't handle `svg` elements' `height` and `width` attributes like you'd expect, and the common workaround is to add CSS properties. This patch inserts those where relevant.