### PR TITLE
ODPM-87: Smaller labels on the Likelihood of Search graph

### DIFF
--- a/traffic_stops/static/js/app/common/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/common/ContrabandHitRate.js
@@ -76,6 +76,10 @@ export const ContrabandHitRateBarBase = VisualBase.extend({
       .showLegend(false)
       .showValues(true)
       .tooltips(true)
+      .tooltipContent((key, y, e, graph) => `
+        <h3 class="stops donut-label">${ y }</h3>
+        <p>${ e }</p>
+      `)
       .transitionDuration(350)
       .showControls(false);
 

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -89,7 +89,12 @@ export const LikelihoodOfSearchBase = VisualBase.extend({
       .showValues(true)
       .tooltips(true)
       .transitionDuration(350)
-      .showControls(false);
+      .showControls(false)
+      .tooltipContent((key, y, e, graph) => `
+        <h3 class="stops donut-label">${ key }</h3>
+        <p>${ y }</p>
+        <p>${ e }</p>
+      `);
 
     this.chart.yAxis
         .axisLabel('Additional percentage or search by search-cause')

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -43,7 +43,10 @@ var CensusRatioDonut = VisualBase.extend({
       .labelType("percent")
       .donutRatio(0.35)
       .labelThreshold(0.05)
-      .donut(true);
+      .donut(true)
+      .tooltipContent((key, y, e, graph) => (
+        `<h3 class="stops donut-label">${ key }</h3><p>${ y.replace(/\.\d*/, '') }</p>`
+      ));
   },
   drawStartup: function(){},
   drawChart: function(){

--- a/traffic_stops/static/js/app/states/nc/UseOfForce.js
+++ b/traffic_stops/static/js/app/states/nc/UseOfForce.js
@@ -86,7 +86,11 @@ var UseOfForceBarChart = VisualBase.extend({
       .showControls(true)
       .groupSpacing(0.1)
       .width(this.get("width"))
-      .height(this.get("height"));
+      .height(this.get("height"))
+      .tooltipContent((key, y, e, graph) => `
+        <h3 class="stops donut-label">${ key }</h3>
+        <p>${ e } in ${ y }</p>
+      `);
 
     this.chart.xAxis
         .axisLabel('Year');


### PR DESCRIPTION
Overly large hover labels no more! This rearranges the content of the Likelihood of Search graph's tooltips so as to be less obtrusive.