### PR TITLE
ODPM-90: adding anchor offsets

### DIFF
--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -11,12 +11,12 @@
 {% endblock race-selector %}
 
 {% block census-link %}
-<li id="census-link-item"><a href="#wrap">Census Demographics</a></li>
+<li id="census-link-item" class="optional"><a href="#demographics">Census Demographics</a></li>
 {% endblock census-link %}
 
 {% block census-display %}
   <!-- census data -->
-  <div id="census_row" class="row">
+  <div id="census_row" class="row optional">
     <div class="col-md-12 headline">
       <h2 id='demographics'>2010 census data</h2>
     </div>

--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -11,7 +11,7 @@
 {% endblock race-selector %}
 
 {% block census-link %}
-<li id="census-link-item"><a href="#demographics">Census Demographics</a></li>
+<li id="census-link-item"><a href="#wrap">Census Demographics</a></li>
 {% endblock census-link %}
 
 {% block census-display %}

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -18,11 +18,11 @@ var CensusHandler = DataHandlerBase.extend({
     if(data.length>0){
       data = d3.map(data[0]);
       this.set("data", data);
-    } else {
-      $('#census_row').remove();
-      $('#census-link-item').remove();
-      $('body').scrollspy('refresh');
+      $('#census_row').show();
+      $('#census-link-item').show();
     }
+
+    $('body').scrollspy('refresh');
   }
 });
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -407,6 +407,24 @@ h2.officer {
 }
 
 /***
+ * For census data and other rows that may or may not be needed, depending
+ * on the results coming from the API.
+ */
+.optional,
+.nav li.optional {
+  display: none;
+}
+
+/***
+ * To accommodate the extra padding added to anchor elements without breaking
+ * the accessibility of controls (see `fixAnchorElements in base
+ * agency_detail.html), we hide overflow in rows.
+ */
+.row {
+  overflow: hidden;
+}
+
+/***
  * Sticky sub-navigation bar on agency detail pages.
  * *Not* sticky on mobile view.
  */
@@ -474,6 +492,11 @@ nav.graphs-nav {
       @media (min-width: 771px) {
         height: 80px;
         width: 100%;
+      }
+
+      @media (max-width: 770px) {
+        height: 0!important;
+        width: 0!important;
       }
     }
   }

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -64,13 +64,15 @@
       {% endblock graph-code %}
 
       var $body = $('body');
+      var $padder = $('.affix-padder');
+      var $graphsNav = $('#graphs-nav');
 
       $body.scrollspy({ target: '#graphs-nav', offset: 50 });
       $('window').on('load', function () {
         $body.scrollspy('refresh');
       });
 
-      $('#graphs-nav').affix({
+      $graphsNav.affix({
         offset: {
           top: function () {
             return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
@@ -79,7 +81,28 @@
             return $('.footer').outerHeight(true);
           }
         }
+      })
+      .on('affixed.bs.affix', function () {
+        $padder.height($graphsNav.outerHeight());
+      })
+      .on('affixed-top.bs.affix', function () {
+        $padder.height(0);
       });
+
+      (function fixAnchorElements () {
+        var $anchors = $('.headline > h2');
+        var offset = $('.state-banner').outerHeight();
+
+        $anchors
+          .slice(1, $anchors.length)
+          .each(function () {
+            $(this).css({
+              'padding-top': offset + 'px'
+            , 'margin-top': (-offset) + 'px'
+            })
+          })
+        ;
+      })();
     });
   </script>
 {% endblock extra-js %}

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -71,37 +71,43 @@
       {% endblock graph-code %}
 
       var $body = $('body');
+      var $window = $(window);
       var $padder = $('.affix-padder');
       var $graphsNav = $('#graphs-nav');
+      var BREAKPOINT = 770;
 
       $body.scrollspy({ target: '#graphs-nav', offset: 50 });
       $('window').on('load', function () {
         $body.scrollspy('refresh');
       });
 
-      $graphsNav.affix({
-        offset: {
-          top: function () {
-            return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
-          },
-          bottom: function () {
-            return $('.footer').outerHeight(true);
+      if ($window.width() > BREAKPOINT) {
+        $graphsNav.affix({
+          offset: {
+            top: function () {
+              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
+            },
+            bottom: function () {
+              return $('.footer').outerHeight(true);
+            }
           }
-        }
-      })
-      .on('affixed.bs.affix', function () {
-        $padder.height($graphsNav.outerHeight());
-      })
-      .on('affixed-top.bs.affix', function () {
-        $padder.height(0);
-      });
+        })
+        .on('affixed.bs.affix', function () {
+          $padder.height($graphsNav.outerHeight());
+        })
+        .on('affixed-top.bs.affix', function () {
+          $padder.height(0);
+        });
+      }
 
       (function fixAnchorElements () {
         var $anchors = $('.headline > h2');
-        var offset = $('.state-banner').outerHeight();
+        var offset =
+          $('.navbar').height()
+          + ($window.width() > BREAKPOINT ? $graphsNav.outerHeight() : 0)
+          + 12;
 
         $anchors
-          .slice(1, $anchors.length)
           .each(function () {
             $(this).css({
               'padding-top': offset + 'px'


### PR DESCRIPTION
Previously, the anchor links in the sticky header would move you down the page so far that the header itself obscured the target.

This adds some dynamically-set offsets to the targets (a combination of top padding and a negative top margin) to scroll the page only an appropriate amount.

Also, the census link, since it's always at the top of the page, is more easily set by just pointing the link at the top of the content wrapper.