### PR TITLE
ODPM-32 - use full agency names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ before_script:
 
 script:
   - coverage run manage.py test
-  - coverage report -m --fail-under 62
+  - coverage report -m --fail-under 63
   - flake8 .
   - npm test

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 	# Run all tests and report coverage
 	# Requires coverage
 	coverage run manage.py test
-	coverage report -m --fail-under 62
+	coverage report -m --fail-under 63
 
 lint-py:
 	# Check for Python formatting issues

--- a/md/data/MD_agencies.csv
+++ b/md/data/MD_agencies.csv
@@ -1,0 +1,128 @@
+Agency Code,Agency Name,GEOID
+AACCPSP,AACCPSP,
+AACOPD,Anne Arundel County Police Department,
+AACOSHERIFF,Anne Arundel County Sheriff's Office,
+ABERDEEN,Aberdeen Police Department,16000US2400125
+ALLEGANY,Allegany County Sheriff's Office,
+ANNAPOLIS,Annapolis Police Department,16000US2401600
+BACOPD,Baltimore County Police Department,
+BALTIMORE,BALTIMORE,
+BALTIMORESCHOOL,Baltimore City Schools Police,
+BALTOENVIR,Baltimore City Environmental Police,
+BALTSHERIFF,Baltimore County Sheriff's Office,
+BELAIR,Bel Air Police Department,16000US2405550
+BERLIN,Berlin Police Department,16000US2406800
+BERWYNHEIGHTS,Berwyn Heights Police Department,16000US2406925
+BLADENSBURG,Bladensburg Police Department,16000US2407850
+BOONSBORO,Boonsboro Police Department,16000US2408625
+BOWIE,Bowie Police Department,16000US2408775
+BOWIEUNIV,"Bowie State University, Department of Public Safety",
+BRENTWOOD,Brentwood Police Department,16000US2409500
+BRUNSWICK,Brunswick Police Department,16000US2410900
+CALVERT,Calvert County Sheriff's Office,
+CAMBRIDGE,Cambridge Police Department,16000US2412400
+CAPITOLHEIGHTS,Capitol Heights Police Department,16000US2413000
+CAROLINE,Caroline County Sheriff's Department,
+CARROLL,Carroll County Sheriff's Office,
+CECIL,Cecil County Sheriff's Office,
+CENTREVILLE,Centreville Police Department,16000US2414950
+CHARLES,Charles County Sheriff's Office,
+CHESTERTOWN,Chestertown Police Department,16000US2416225
+CHEVERLY,Cheverly Police Department,16000US2416550
+CHEVYCHASE,Chevy Chase Village Police Department,16000US2416787
+COLMAR,Colmar Manor Police Department,16000US2418850
+COMPTROLLER,COMPTROLLER,
+COPPIN,Coppin State University Police Department,
+COTTAGECITY,Cottage City Police Department,16000US2420050
+CROFTON,Crofton Police Department,
+CUMBERLAND,Cumberland Police Department,16000US2421325
+DELMAR,Delmar Police Department,16000US2422600
+DELTA,DELTA,
+DENTON,Denton Police Department,16000US2422725
+DGS,Department of General Services-Maryland Capital Police,
+DHMH,DHMH,
+DISTHEIGHTS,District Heights Police Department,16000US2423025
+DORCHESTER,Dorchester County Sheriff's Office,
+EASTON,Easton Police Department,16000US2424475
+EDMONSTON,Edmonston Police Department,16000US2425425
+ELKTON,Elkton Police Department,16000US2425800
+FAIRMOUNT,Fairmont Heights Police Department,
+FEDERALSBURG,Federalsburg Police Department,16000US2427900
+FORESTHEIGHTS,Forest Heights Police Department,16000US2428725
+FORTDETRICK,Fort Detrick Police,
+FORTMEADE,Fort Meade Police,
+FREDERICK,Frederick County Sheriff's Office,
+FREDERICKPD,Frederick City Police Department,16000US2430325
+FROSTBURG,Frostburg State University Police Department,
+FRUITLAND,Fruitland Police Department,16000US2430950
+GAITHERSBURG,Gaithersburg Police Department,16000US2431175
+GARRETT,Garrett County Sheriff's Office,
+GLENARDEN,Glenarden Police Department,16000US2432500
+GREENBELT,Greenbelt Police Department,16000US2434775
+GREENSBORO,Greensboro Police Department,16000US2435200
+HAGERSTOWN,Hagerstown Police Department,16000US2436075
+HAMPSTEAD,Hampstead Police Department,16000US2436500
+HANCOCK,Hancock Police Department,16000US2436600
+HARFORD,Harford County Sheriff's Office,
+HAVREDEGRACE,Havre De Grace Police Department,16000US2437600
+HOCPD,Howard County Police Department,
+HURLOCK,Hurlock Police Department,16000US2441125
+HYATTSVILLE,Hyattsville City Police Department,16000US2441250
+KENT,Kent County Sheriff's Office,
+LANDOVER,Landover Hills Police Department,16000US2445400
+LAPLATA,La Plata Police Department,16000US2445750
+LAUREL,Laurel Police Department,16000US2445900
+MANCHESTER,Manchester Police Department,16000US2449950
+MCPARK,Maryland-National Capital Park Police,
+MDTA,Maryland Transportation Authority Police,
+MONTGOMERY,Montgomery County Police Department,
+MONTSHERIFF,Montgomery County Sheriff's Office,
+MORNINGSIDE,Morningside Police Department,16000US2453625
+MSP,Maryland State Police,
+MTA,Maryland Transit Administration Police,
+MTRAINIER,Mount Rainier Police Department,16000US2454275
+MVA,Maryland Motor Vehicle Administration Police Department,
+NCPD,New Carrollton Police Department,16000US2455400
+NRP,Natural Resource Police,
+OAKLAND,Oakland Police Department,16000US2457650
+OCEANCITY,Ocean City Police Department,16000US2458225
+OCEANPINES,Ocean Pines Police Department,
+OXFORD,Oxford Police Department,16000US2459450
+PERRYVILLE,Perryville Police Department,16000US2461150
+PGCOPD,Prince George's County Police Department,
+PGCOSHERIFF,Prince George's County Sheriff's Office,
+PGPARK,PGPARK,
+POCOMOKE,Pokomoke City Police Department,16000US2462475
+PRINCESSANNE,Princess Anne Police Department,16000US2464000
+QACSO,Queen Anne's County Sheriff's Office,
+RIDGELY,Ridgley Police Department,
+RISINGSUN,Rising Sun Police Department,16000US2466275
+RIVERDALE,Riverdale Park Police Department,16000US2466635
+ROCKHALL,Rock Hall Police Department,16000US2467400
+ROCKVILLE,Rockville City Police Department,16000US2467675
+SALISBURY,Salisbury Police Department,16000US2469925
+SALISBURYUNIV,Salisbury University Police Department,
+SEATPLEASANT,Seat Pleasant Police Department,16000US2470850
+SMITHSBURG,Smithsburg Police Department,16000US2472900
+SNOWHILL,Snow Hill Police Department,16000US2473075
+SOMERSET,Somerset County Sheriff's Office,
+STMARYS,St. Mary's County Sheriff's Office,
+STMICHAELS,St. Michaels Police Department,16000US2469825
+SYKESVILLE,Sykesville Police Department,16000US2476550
+TAKOMA,Takoma Park Police Department,16000US2476650
+TALBOT,Talbot County Sheriff's Office,
+TANEYTOWN,Taneytown Police Department,16000US2476725
+THURMONT,Thurmont Police Department,16000US2477825
+TOWSONU,Towson University Police Department,
+TRAPPE,Trappe Police Department,16000US2478575
+UBALTPD,University of Baltimore Police Department,
+UMARLBORO,Upper Marlboro Police Department,16000US2479875
+UMB,"University of Maryland, Baltimore Police Department",
+UMBC,"University of Maryland, Baltimore County Police Department",
+UMCP,"University of Maryland, College Park Police Department",
+UMES,University of Maryland Eastern Shore,
+UNIVERSITYPARK,University Park Police Department,16000US2479675
+WASHINGTON,Washington County Sheriff's Office,
+WESTMINSTER,Westminster Police Department,16000US2483100
+WICOMICO,Wicomico County Sheriff's Office,
+WORCESTER,Worcester County Sheriff's Office,

--- a/md/data/analyzer.py
+++ b/md/data/analyzer.py
@@ -8,7 +8,7 @@ import logging
 import pandas as pd
 
 from tsdata.utils import download_and_unzip_data, get_datafile_path
-from md.data.importer import fix_STOP_REASON, load_xls
+from md.data.importer import fix_AGENCY_column, fix_STOP_REASON, load_xls
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,7 @@ def analyze(stops, report):
     """
     stops['date'] = pd.to_datetime(stops['STOPDATE'])
     stops['cleaned-STOP_REASON'] = stops['STOP_REASON'].apply(fix_STOP_REASON)
+    fix_AGENCY_column(stops)
 
     stats_for_state_landing_page(stops, report)
 

--- a/md/data/analyzer.py
+++ b/md/data/analyzer.py
@@ -8,7 +8,9 @@ import logging
 import pandas as pd
 
 from tsdata.utils import download_and_unzip_data, get_datafile_path
-from md.data.importer import fix_AGENCY_column, fix_STOP_REASON, load_xls
+from md.data.importer import (
+    fix_AGENCY_column, fix_STOP_REASON, load_xls, process_time_of_stop
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +26,8 @@ def stats_for_state_landing_page(stops, report):
     lines = ['', 'Dataset facts']
     lines.append(
         '  Time frame: {} - {}'.format(
-            stops.date[0],
-            stops.date[len(stops.date) - 1]
+            stops.date.iloc[0],
+            stops.date.iloc[-1]
         )
     )
     lines.append(
@@ -50,9 +52,12 @@ def stats_for_state_landing_page(stops, report):
 
 def analyze(stops, report):
     """
-    Note: This runs on unprocessed data -- data as loaded from the .xlsx
+    This runs on largely unprocessed data -- data as loaded from the .xlsx
+
+    Dropping of some data is handled by importer.process_time_of_stop(), since
+    the analysis should match the set of data intended for display.
     """
-    stops['date'] = pd.to_datetime(stops['STOPDATE'])
+    stops = process_time_of_stop(stops)
     stops['cleaned-STOP_REASON'] = stops['STOP_REASON'].apply(fix_STOP_REASON)
     fix_AGENCY_column(stops)
 

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -8,7 +8,7 @@
 
 {% block state-subtitle %}
   Browse all known traffic stops to have occurred in Maryland since
-  January 1, 2012
+  January 1, 2013
 {% endblock state-subtitle %}
 
 {% block state-header-graphic %}
@@ -48,23 +48,23 @@
     </tr>
     <tr>
       <td><a href="{% url "md:agency-detail" "77" %}">Maryland State Police</a></td>
-      <td class="text-right">641,952</td>
+      <td class="text-right">639,959</td>
     </tr>
     <tr>
       <td><a href="{% url "md:agency-detail" "80" %}">Montgomery County Police Department</a></td>
-      <td class="text-right">230,317</td>
+      <td class="text-right">227,794</td>
     </tr>
     <tr>
       <td><a href="{% url "md:agency-detail" "10" %}">Baltimore County Police Department</a></td>
-      <td class="text-right">222,241</td>
+      <td class="text-right">216,167</td>
     </tr>
     <tr>
       <td><a href="{% url "md:agency-detail" "79" %}">Maryland Transportation Authority Police</a></td>
-      <td class="text-right">180,312</td>
+      <td class="text-right">179,554</td>
     </tr>
     <tr>
       <td><a href="{% url "md:agency-detail" "5" %}">Anne Arundel County Police Department</a></td>
-      <td class="text-right">126,123</td>
+      <td class="text-right">124,580</td>
     </tr>
   </table>
 {% endblock agencies-table %}
@@ -73,7 +73,7 @@
   <p>
       Open Data Policing aggregates, visualizes, and publishes public
       records related to all known traffic stops to have occurred in Maryland
-      since January 1, 2012. Data is available for most
+      since January 1, 2013. Data is available for most
       Maryland departments and officers serving populations greater
       than <i>n</i>.
   </p>
@@ -93,15 +93,15 @@
   <table class='table table-condensed table-hover'>
     <tr>
       <th>Timeframe</th>
-      <td>Jan 1 2012 - Dec 31, 2015</td>
+      <td>Jan 1 2013 - Dec 31, 2015</td>
     </tr>
     <tr>
       <th>Stops</th>
-      <td>2,257,860</td>
+      <td>2,227,042</td>
     </tr>
     <tr>
       <th>Searches</th>
-      <td>79,586</td>
+      <td>66,605</td>
     </tr>
     <tr>
       <th>Agencies</th>

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -47,23 +47,23 @@
       <th class="text-right">Stops</th>
     </tr>
     <tr>
-      <td><a href="{% url "md:agency-detail" "80" %}">MSP</a></td>
+      <td><a href="{% url "md:agency-detail" "77" %}">Maryland State Police</a></td>
       <td class="text-right">641,952</td>
     </tr>
     <tr>
-      <td><a href="{% url "md:agency-detail" "77" %}">Montgomery</a></td>
+      <td><a href="{% url "md:agency-detail" "80" %}">Montgomery County Police Department</a></td>
       <td class="text-right">230,317</td>
     </tr>
     <tr>
-      <td><a href="{% url "md:agency-detail" "7" %}">BACOPD</a></td>
+      <td><a href="{% url "md:agency-detail" "10" %}">Baltimore County Police Department</a></td>
       <td class="text-right">222,241</td>
     </tr>
     <tr>
-      <td><a href="{% url "md:agency-detail" "76" %}">MDTA</a></td>
+      <td><a href="{% url "md:agency-detail" "79" %}">Maryland Transportation Authority Police</a></td>
       <td class="text-right">180,312</td>
     </tr>
     <tr>
-      <td><a href="{% url "md:agency-detail" "2" %}">AACOPD</a></td>
+      <td><a href="{% url "md:agency-detail" "5" %}">Anne Arundel County Police Department</a></td>
       <td class="text-right">126,123</td>
     </tr>
   </table>

--- a/md/tests/test_normalization.py
+++ b/md/tests/test_normalization.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 import pandas as pd
 
 from md.data.importer import (
-    add_age_column, add_date_column, add_purpose_column, fix_ETHNICITY,
-    fix_GENDER, fix_SEIZED, fix_STOP_REASON, fix_TIME_OF_STOP
+    add_age_column, add_date_column, add_purpose_column, fix_AGENCY_column,
+    fix_ETHNICITY, fix_GENDER, fix_SEIZED, fix_STOP_REASON, fix_TIME_OF_STOP
 )
 from md.models import UNKNOWN_PURPOSE
 
@@ -158,3 +158,11 @@ class TestFieldNormalization(TestCase):
             self.assertEqual(stops.purpose[i], expected_purpose, 'Expected purpose %d for "%s", got %d' % (
                 expected_purpose, raw_reason, stops.purpose[i]
             ))
+
+    def test_agency_names(self):
+        stops = pd.DataFrame({
+            'AGENCY': ['!@#$', 'BACOPD', 'CECIL'],
+            'expected_AGENCY': ['!@#$', 'Baltimore County Police Department', "Cecil County Sheriff's Office"]
+        })
+        fix_AGENCY_column(stops)
+        self.assertTrue(all(stops.AGENCY == stops.expected_AGENCY))

--- a/traffic_stops/static/js/app/states/md/defaults.js
+++ b/traffic_stops/static/js/app/states/md/defaults.js
@@ -2,7 +2,7 @@ import d3 from 'd3';
 
 // Traffic Stops global defaults
 export default {
-  start_year: 2012,     // start-year for reporting requirement
+  start_year: 2013,     // start-year for reporting requirement
   end_year: new Date().getUTCFullYear(),       // end-date for latest dataset
   ethnicities: [
     'White',


### PR DESCRIPTION
The full agency names are in a new ``.csv`` file under ``md/data`` which is used during import to update the pandas ``DataFrame`` with the full names.  This ``.csv`` also contains census ``GEOID`` values for some agencies, but those values aren't yet used.

The dataset facts in the MD landing page are updated to reflect the agency names and, as of a prior ticket, the dropping of 2012 data.

Lastly, the Python test coverage requirement is increased by a trivial amount which reflects a marginal coverage improvement with this pull request.