### PR TITLE
Fixing erroneous transition

### DIFF
--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -55,11 +55,11 @@ var CensusRatioDonut = VisualBase.extend({
     nv.addGraph(() => {
       d3.select(this.svg[0])
           .datum(data)
-        .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")
           .style({ width:  `${this.get('width')}px`
                  , height: `${this.get('height')}px` })
+        .transition().duration(1200)
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);


### PR DESCRIPTION
The Internet Explorer bugfix code (`.style(/*...*/)`) for the Census donut graph should be moved above the `.transition` call, or else it'll zoom in in a weird and undesired way.

To verify:

* Look at an agency detail page for which there is census data.
* Verify that the census donut does not jarringly zoom in on page load.
* 👍 