### PR TITLE
ODPM-37: find an agency

### DIFF
--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -15,6 +15,19 @@
   <img src="{% static "svg/noun_19618_cc-white.svg" %}" class="state md">
 {% endblock state-header-graphic %}
 
+{% block agency-intro %}
+  <p class='nc-agency-intro'>
+    Review agency-level data on the racial and ethnic demographics of people
+    stopped, searched, and subjected to force in the course of traffic stops
+    in a given jurisdiction.
+  </p>
+
+  <p class="nc-agency-intro">
+    <a href="{% url "md:agency-list" %}">Click here</a> to browse a list of
+    all agencies for which data is available.
+  </p>
+{% endblock agency-intro %}
+
 {% block search-form %}
   <h4>View Agency Dashboard</h4>
   <form role="form" id="agency_search" action='{% url "md:home" %}' method="get" accept-charset="utf-8">

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -16,13 +16,13 @@
 {% endblock state-header-graphic %}
 
 {% block agency-intro %}
-  <p class='nc-agency-intro'>
+  <p class='agency-intro'>
     Review agency-level data on the racial and ethnic demographics of people
     stopped, searched, and subjected to force in the course of traffic stops
     in a given jurisdiction.
   </p>
 
-  <p class="nc-agency-intro">
+  <p class="agency-intro">
     <a href="{% url "md:agency-list" %}">Click here</a> to browse a list of
     all agencies for which data is available.
   </p>

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -34,16 +34,16 @@
       <div class="form-group">
       {% csrf_token %}
       <div class="input-group">
-        {{ agency_form.agency }}
+        {{ form.agency }}
         <span class="input-group-btn">
           <button class="btn btn-primary" type="button">View</button>
         </span>
       </div><!-- /input-group -->
-      {% if agency_form.agency.errors %}
+      {% if form.agency.errors %}
           <div class="alert alert-warning alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
               <ul>
-              {% for error in agency_form.agency.errors %}
+              {% for error in form.agency.errors %}
                   <li><strong>{{ error }}</strong></li>
               {% endfor %}
               </ul>

--- a/md/templates/md/agency_list.html
+++ b/md/templates/md/agency_list.html
@@ -1,12 +1,21 @@
-{% extends "base.html" %}
+{% extends "agency_list.html" %}
 
-{% block content %}
-<h2>Agencies</h2>
-<div class="row">
-    <ul>
-        {% for agency in object_list %}
-        <li><a href="{% url "md:agency-detail" agency.pk %}">{{ agency }}</a></li>
-        {% endfor %}
-    </ul>
-</div>
-{% endblock %}
+{% block stops-search-url %}{% url 'md:stops-search' %}{% endblock %}
+
+{% block home-url %}{% url "md:home" %}{% endblock home-url %}
+
+{% block help-text %}
+  Enter an agency name into the search field above to review data on the
+  ethnic demographics of people stopped, searched, and subjected to force
+  in the course of traffic stops in a given jurisdiction. Data is available
+  for most Maryland departments and officers serving populations greater
+  than <i>n</i>. Maryland law requires all such agencies to report their
+  data on a monthly basis to the Maryland state government; however, some
+  datasets are incomplete or remain unreported. Where data sets are incomplete
+  or missing from the website, it is because they have not been reported to
+  the state agency from which the site derives its records. Open Data Policing
+  does not have access to, nor does it publish, the names of officers, drivers,
+  or passengers involved in traffic stops.
+{% endblock help-text %}
+
+{% block agency-link %}{% url "md:agency-detail" agency.pk %}{% endblock agency-link %}

--- a/md/tests/test_api.py
+++ b/md/tests/test_api.py
@@ -4,13 +4,13 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 import pytz
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APITransactionTestCase
 
 from md.models import Agency, ETHNICITY_CHOICES, PURPOSE_CHOICES
 from md.tests import factories
 
 
-class AgencyTests(APITestCase):
+class AgencyTests(APITransactionTestCase):
 
     def test_list_agencies(self):
         """Test Agency list"""

--- a/md/tests/test_api.py
+++ b/md/tests/test_api.py
@@ -11,6 +11,7 @@ from md.tests import factories
 
 
 class AgencyTests(APITestCase):
+    multi_db = True
 
     def test_list_agencies(self):
         """Test Agency list"""

--- a/md/tests/test_api.py
+++ b/md/tests/test_api.py
@@ -4,13 +4,13 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 import pytz
 from rest_framework import status
-from rest_framework.test import APITransactionTestCase
+from rest_framework.test import APITestCase
 
 from md.models import Agency, ETHNICITY_CHOICES, PURPOSE_CHOICES
 from md.tests import factories
 
 
-class AgencyTests(APITransactionTestCase):
+class AgencyTests(APITestCase):
 
     def test_list_agencies(self):
         """Test Agency list"""

--- a/md/tests/test_normalization.py
+++ b/md/tests/test_normalization.py
@@ -12,6 +12,7 @@ from md.models import UNKNOWN_PURPOSE
 
 
 class TestFieldNormalization(TestCase):
+    # if db calls are added: multi_db = True
 
     def test_ethnicity(self):
         data = (

--- a/md/tests/test_views.py
+++ b/md/tests/test_views.py
@@ -1,0 +1,63 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from md.models import Agency, Stop
+
+
+class ViewTests(TestCase):
+    def tearDown(self):
+        Stop.objects.all().delete()
+        Agency.objects.all().delete()
+
+    def test_home(self):
+        response = self.client.get(reverse('md:home'))
+        self.assertEqual(200, response.status_code)
+
+    def test_agency_detail(self):
+        agency = Agency.objects.create(name="Maryland State Police")
+        response = self.client.get(reverse('md:agency-detail', args=[agency.pk]))
+        self.assertEqual(200, response.status_code)
+
+    def test_agency_list(self):
+        response = self.client.get(reverse('md:agency-list'))
+        self.assertEqual(200, response.status_code)
+
+    def test_agency_list_sorted_agencies(self):
+        """
+        Verify that agencies are delivered in an appropriately sorted and
+        chunked form.
+        """
+        Agency.objects.create(name="Abc")
+        Agency.objects.create(name="Def")
+        Agency.objects.create(name="Ghi")
+        Agency.objects.create(name="Abc_")
+        Agency.objects.create(name="Def_")
+        Agency.objects.create(name="Ghi_")
+        Agency.objects.create(name="Abc__")
+        Agency.objects.create(name="Def__")
+        Agency.objects.create(name="Ghi__")
+        Agency.objects.create(name="Abc___")
+        Agency.objects.create(name="Def___")
+        Agency.objects.create(name="Ghi___")
+        Agency.objects.create(name="Abc____")
+        Agency.objects.create(name="Def____")
+        Agency.objects.create(name="Ghi____")
+
+        response = self.client.get(reverse('md:agency-list'))
+        sorted_agencies = response.context['sorted_agencies']
+
+        # Verify that there are three alphabetic categories
+        self.assertEqual(3, len(sorted_agencies))
+
+        keys = [pair[0] for pair in sorted_agencies]
+        # Verify that the relevant letters are in there
+        self.assertTrue("A" in keys)
+        self.assertTrue("D" in keys)
+        self.assertTrue("G" in keys)
+
+        # Verify that each alphabetic category contains three chunks
+        # with the appropriate number of pieces (i.e. 2, 2, 1)
+        for (letter, chunks) in sorted_agencies:
+            self.assertEqual(3, len(chunks))
+            self.assertEqual(2, len(chunks[0]))
+            self.assertEqual(2, len(chunks[1]))
+            self.assertEqual(1, len(chunks[2]))

--- a/md/tests/test_views.py
+++ b/md/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from md.models import Agency, Stop
+from md.tests import factories
 
 
 class ViewTests(TestCase):
@@ -11,7 +12,7 @@ class ViewTests(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_agency_detail(self):
-        agency = Agency.objects.create(name="Maryland State Police")
+        agency = factories.AgencyFactory(name="Maryland State Police")
         response = self.client.get(reverse('md:agency-detail', args=[agency.pk]))
         self.assertEqual(200, response.status_code)
 
@@ -24,21 +25,21 @@ class ViewTests(TestCase):
         Verify that agencies are delivered in an appropriately sorted and
         chunked form.
         """
-        Agency.objects.create(name="Abc")
-        Agency.objects.create(name="Def")
-        Agency.objects.create(name="Ghi")
-        Agency.objects.create(name="Abc_")
-        Agency.objects.create(name="Def_")
-        Agency.objects.create(name="Ghi_")
-        Agency.objects.create(name="Abc__")
-        Agency.objects.create(name="Def__")
-        Agency.objects.create(name="Ghi__")
-        Agency.objects.create(name="Abc___")
-        Agency.objects.create(name="Def___")
-        Agency.objects.create(name="Ghi___")
-        Agency.objects.create(name="Abc____")
-        Agency.objects.create(name="Def____")
-        Agency.objects.create(name="Ghi____")
+        factories.AgencyFactory(name="Abc")
+        factories.AgencyFactory(name="Def")
+        factories.AgencyFactory(name="Ghi")
+        factories.AgencyFactory(name="Abc_")
+        factories.AgencyFactory(name="Def_")
+        factories.AgencyFactory(name="Ghi_")
+        factories.AgencyFactory(name="Abc__")
+        factories.AgencyFactory(name="Def__")
+        factories.AgencyFactory(name="Ghi__")
+        factories.AgencyFactory(name="Abc___")
+        factories.AgencyFactory(name="Def___")
+        factories.AgencyFactory(name="Ghi___")
+        factories.AgencyFactory(name="Abc____")
+        factories.AgencyFactory(name="Def____")
+        factories.AgencyFactory(name="Ghi____")
 
         response = self.client.get(reverse('md:agency-list'))
         sorted_agencies = response.context['sorted_agencies']

--- a/md/tests/test_views.py
+++ b/md/tests/test_views.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from md.models import Agency, Stop
+from md.models import Stop
 from md.tests import factories
 
 

--- a/md/tests/test_views.py
+++ b/md/tests/test_views.py
@@ -4,9 +4,7 @@ from md.models import Agency, Stop
 
 
 class ViewTests(TestCase):
-    def tearDown(self):
-        Stop.objects.all().delete()
-        Agency.objects.all().delete()
+    multi_db = True
 
     def test_home(self):
         response = self.client.get(reverse('md:home'))

--- a/md/urls.py
+++ b/md/urls.py
@@ -8,7 +8,7 @@ router.register(r'agency', api.AgencyViewSet, base_name="agency-api")
 
 
 urlpatterns = [  # noqa
-    url(r'^$', views.home, name='home'),
+    url(r'^$', views.Home.as_view(), name='home'),
     url(r'^search/$', views.search, name='stops-search'),
     url(r'^agency/$', views.AgencyList.as_view(), name='agency-list'),
     url(r'^agency/(?P<pk>\d+)/$', views.AgencyDetail.as_view(),

--- a/md/views.py
+++ b/md/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, redirect, Http404
 from django.views.generic import ListView, DetailView, View, TemplateView
 from .models import Stop, Agency
 from . import forms
+import math
 
 
 def home(request):
@@ -28,8 +29,48 @@ def search(request):
     return render(request, 'md/search.html', context)
 
 
+def get_chunks(xs, chunk_count=3):
+    """
+    Helper function to split a list into roughly equally sized chunks.
+    """
+    chunk_width = math.ceil(len(xs) / chunk_count)
+    ranges = range(0, len(xs), chunk_width)
+    return [xs[x:x + chunk_width] for x in ranges]
+
+
 class AgencyList(ListView):
     model = Agency
+
+    def get_context_data(self, **kwargs):
+        context = super(AgencyList, self).get_context_data(**kwargs)
+
+        if self.request.method == 'GET' and self.request.GET:
+            form = forms.AgencySearchForm(request.GET)
+            if form.is_valid():
+                agency = form.cleaned_data['agency']
+                return redirect('md:agency-detail', agency.pk)
+        else:
+            form = forms.AgencySearchForm()
+
+        # Once we have the "letters present", we want to be able to iterate
+        # over categorized, sorted lists of agencies. Therefore we create
+        # a dict indexed by first letter.
+        sorted_agencies = {}
+
+        for agency in context['agency_list']:
+            initial = agency.name[:1]
+            if initial not in sorted_agencies:
+                sorted_agencies[initial] = []
+            sorted_agencies[initial].append(agency)
+
+        for key in sorted_agencies:
+            sorted_agencies[key].sort(key=lambda x: x.name)
+            sorted_agencies[key] = get_chunks(sorted_agencies[key])
+
+        sorted_agencies = sorted(sorted_agencies.items())
+
+        return dict(context, **{"sorted_agencies": sorted_agencies,
+                                "agency_form": form, })
 
 
 class AgencyDetail(DetailView):

--- a/md/views.py
+++ b/md/views.py
@@ -1,20 +1,22 @@
 from django.shortcuts import render, redirect, Http404
 from django.views.generic import ListView, DetailView, View, TemplateView
+from django.views.generic.edit import ProcessFormView, FormMixin
 from .models import Stop, Agency
 from . import forms
 from traffic_stops.utils import get_chunks
+from collections import defaultdict
 
 
-def home(request):
-    if request.method == 'GET' and request.GET:
-        form = forms.AgencySearchForm(request.GET)
-        if form.is_valid():
-            agency = form.cleaned_data['agency']
-            return redirect('md:agency-detail', agency.pk)
-    else:
-        form = forms.AgencySearchForm()
-    context = {'agency_form': form}
-    return render(request, 'md.html', context)
+class Home(FormMixin, ProcessFormView, TemplateView):
+    form_class = forms.AgencySearchForm
+    template_name = 'md.html'
+
+    def get(self, request, *args, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                return redirect('md:agency-detail', form.cleaned_data['agency'].pk)
+        return super(Home, self).get(request, **kwargs)
 
 
 def search(request):
@@ -29,29 +31,39 @@ def search(request):
     return render(request, 'md/search.html', context)
 
 
-class AgencyList(ListView):
+class AgencyList(FormMixin, ListView):
     model = Agency
+    form_class = forms.AgencySearchForm
+    success_url = 'md:agency-detail'
+
+    def get_success_url(self, pk, **kwargs):
+        success = self.get_success_url()
+        return redirect(success, pk)
+
+    def get(self, request, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                return self.get_success_url(pk=form.cleaned_data['agency'].pk)
+        return super(AgencyList, self).get(request, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(AgencyList, self).get_context_data(**kwargs)
 
-        if self.request.method == 'GET' and self.request.GET:
-            form = forms.AgencySearchForm(request.GET)
-            if form.is_valid():
-                agency = form.cleaned_data['agency']
-                return redirect('md:agency-detail', agency.pk)
-        else:
-            form = forms.AgencySearchForm()
+        # The following seems to be all ProcessFormView really gives us.
+        # It causes collisions with ListView's get method. Hence
+        # we just add it as a trivial context-modification snippet.
+        form_class = self.get_form_class()
+        form = self.get_form(form_class)
+        context['form'] = form
 
         # Once we have the "letters present", we want to be able to iterate
         # over categorized, sorted lists of agencies. Therefore we create
         # a dict indexed by first letter.
-        sorted_agencies = {}
+        sorted_agencies = defaultdict(list)
 
         for agency in context['agency_list']:
             initial = agency.name[:1]
-            if initial not in sorted_agencies:
-                sorted_agencies[initial] = []
             sorted_agencies[initial].append(agency)
 
         for key in sorted_agencies:
@@ -60,8 +72,10 @@ class AgencyList(ListView):
 
         sorted_agencies = sorted(sorted_agencies.items())
 
-        return dict(context, **{"sorted_agencies": sorted_agencies,
-                                "agency_form": form, })
+        context['sorted_agencies'] = sorted_agencies
+        context['agency_form'] = form
+
+        return context
 
 
 class AgencyDetail(DetailView):

--- a/md/views.py
+++ b/md/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect, Http404
 from django.views.generic import ListView, DetailView, View, TemplateView
 from .models import Stop, Agency
 from . import forms
-import math
+from traffic_stops.utils import get_chunks
 
 
 def home(request):
@@ -27,15 +27,6 @@ def search(request):
         'form': form,
     }
     return render(request, 'md/search.html', context)
-
-
-def get_chunks(xs, chunk_count=3):
-    """
-    Helper function to split a list into roughly equally sized chunks.
-    """
-    chunk_width = math.ceil(len(xs) / chunk_count)
-    ranges = range(0, len(xs), chunk_width)
-    return [xs[x:x + chunk_width] for x in ranges]
 
 
 class AgencyList(ListView):

--- a/md/views.py
+++ b/md/views.py
@@ -1,22 +1,17 @@
-from django.shortcuts import render, redirect, Http404
-from django.views.generic import ListView, DetailView, View, TemplateView
+from django.shortcuts import render, redirect
+from django.views.generic import ListView, View, TemplateView
 from django.views.generic.edit import ProcessFormView, FormMixin
 from .models import Stop, Agency
 from . import forms
 from traffic_stops.utils import get_chunks
 from collections import defaultdict
+from traffic_stops import base_views
 
 
-class Home(FormMixin, ProcessFormView, TemplateView):
+class Home(base_views.Home):
     form_class = forms.AgencySearchForm
     template_name = 'md.html'
-
-    def get(self, request, *args, **kwargs):
-        if request.GET:
-            form = self.get_form_class()(request.GET)
-            if form.is_valid():
-                return redirect('md:agency-detail', form.cleaned_data['agency'].pk)
-        return super(Home, self).get(request, **kwargs)
+    success_url = 'md:agency-detail'
 
 
 def search(request):
@@ -31,64 +26,12 @@ def search(request):
     return render(request, 'md/search.html', context)
 
 
-class AgencyList(FormMixin, ListView):
+class AgencyList(base_views.AgencyList):
     model = Agency
     form_class = forms.AgencySearchForm
     success_url = 'md:agency-detail'
 
-    def get_success_url(self, pk, **kwargs):
-        success = self.get_success_url()
-        return redirect(success, pk)
 
-    def get(self, request, **kwargs):
-        if request.GET:
-            form = self.get_form_class()(request.GET)
-            if form.is_valid():
-                return self.get_success_url(pk=form.cleaned_data['agency'].pk)
-        return super(AgencyList, self).get(request, **kwargs)
-
-    def get_context_data(self, **kwargs):
-        context = super(AgencyList, self).get_context_data(**kwargs)
-
-        # The following seems to be all ProcessFormView really gives us.
-        # It causes collisions with ListView's get method. Hence
-        # we just add it as a trivial context-modification snippet.
-        form_class = self.get_form_class()
-        form = self.get_form(form_class)
-        context['form'] = form
-
-        # Once we have the "letters present", we want to be able to iterate
-        # over categorized, sorted lists of agencies. Therefore we create
-        # a dict indexed by first letter.
-        sorted_agencies = defaultdict(list)
-
-        for agency in context['agency_list']:
-            initial = agency.name[:1]
-            sorted_agencies[initial].append(agency)
-
-        for key in sorted_agencies:
-            sorted_agencies[key].sort(key=lambda x: x.name)
-            sorted_agencies[key] = get_chunks(sorted_agencies[key])
-
-        sorted_agencies = sorted(sorted_agencies.items())
-
-        context['sorted_agencies'] = sorted_agencies
-        context['agency_form'] = form
-
-        return context
-
-
-class AgencyDetail(DetailView):
+class AgencyDetail(base_views.AgencyDetail):
     model = Agency
-
-    def get_context_data(self, **kwargs):
-        context = super(AgencyDetail, self).get_context_data(**kwargs)
-        agency = context['object']
-        officer_id = self.request.GET.get('officer_id')
-
-        if officer_id:
-            if not Stop.objects.filter(agency=agency, officer_id=officer_id).exists():
-                raise Http404()
-            context['officer_id'] = officer_id
-
-        return context
+    stop_model = Stop

--- a/nc/templates/nc.html
+++ b/nc/templates/nc.html
@@ -34,16 +34,16 @@
       <div class="form-group">
       {% csrf_token %}
         <div class="input-group">
-          {{ agency_form.agency }}
+          {{ form.agency }}
           <span class="input-group-btn">
             <button class="btn btn-primary" type="button">View</button>
           </span>
         </div><!-- /input-group -->
-      {% if agency_form.agency.errors %}
+      {% if form.agency.errors %}
           <div class="alert alert-warning alert-dismissible">
               <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
               <ul>
-              {% for error in agency_form.agency.errors %}
+              {% for error in form.agency.errors %}
                   <li><strong>{{ error }}</strong></li>
               {% endfor %}
               </ul>

--- a/nc/templates/nc.html
+++ b/nc/templates/nc.html
@@ -16,13 +16,13 @@
 {% endblock state-header-graphic %}
 
 {% block agency-intro %}
-  <p class='nc-agency-intro'>
+  <p class='agency-intro'>
     Review agency-level data on the racial and ethnic demographics of people
     stopped, searched, and subjected to force in the course of traffic stops
     in a given jurisdiction.
   </p>
 
-  <p class="nc-agency-intro">
+  <p class="agency-intro">
     <a href="{% url "nc:agency-list" %}">Click here</a> to browse a list of
     all agencies for which data is available.
   </p>

--- a/nc/templates/nc.html
+++ b/nc/templates/nc.html
@@ -15,6 +15,19 @@
   <img src="{% static "svg/noun_19625_cc-white.svg" %}" class="state">
 {% endblock state-header-graphic %}
 
+{% block agency-intro %}
+  <p class='nc-agency-intro'>
+    Review agency-level data on the racial and ethnic demographics of people
+    stopped, searched, and subjected to force in the course of traffic stops
+    in a given jurisdiction.
+  </p>
+
+  <p class="nc-agency-intro">
+    <a href="{% url "nc:agency-list" %}">Click here</a> to browse a list of
+    all agencies for which data is available.
+  </p>
+{% endblock agency-intro %}
+
 {% block search-form %}
   <h4>View Agency Dashboard</h4>
   <form role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">

--- a/nc/templates/nc/agency_list.html
+++ b/nc/templates/nc/agency_list.html
@@ -1,5 +1,37 @@
 {% extends "base.html" %}
 
+{% load selectable_tags staticfiles %}
+
+{% block pre-content %}
+<div class="agency-list-search">
+    <form class="container" role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">
+        <div class="row">
+            <div class="col-md-8 col-md-offset-2">
+                <div class="form-group">
+                {% csrf_token %}
+                  <div class="input-group">
+                    {{ agency_form.agency }}
+                    <span class="input-group-btn">
+                      <button class="btn btn-primary" type="button">View</button>
+                    </span>
+                  </div><!-- /input-group -->
+                {% if agency_form.agency.errors %}
+                    <div class="alert alert-warning alert-dismissible">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <ul>
+                        {% for error in agency_form.agency.errors %}
+                            <li><strong>{{ error }}</strong></li>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock pre-content %}
+
 {% block content %}
 <h2>Agencies</h2>
 <div class="row">
@@ -22,4 +54,22 @@
         {% endfor %}
     </ul>
 </div>
+{% endblock %}
+
+{% block extra-css %}
+    {% include_ui_theme %}
+    {{ agency_form.media.css }}
+{% endblock %}
+
+{% block extra-js %}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
+    {{ agency_form.media.js }}
+    <script type="text/javascript">
+      $(document).ready(function() {
+        var quick_search = $('#agency_search :input[name=agency_0]');
+        quick_search.bind('djselectableselect', function(event, ui) {
+            $(this).parents("form").submit();
+        });
+      });
+    </script>
 {% endblock %}

--- a/nc/templates/nc/agency_list.html
+++ b/nc/templates/nc/agency_list.html
@@ -3,6 +3,19 @@
 {% load selectable_tags staticfiles %}
 
 {% block pre-content %}
+<div class="state-banner agency-list">
+    <div class="row vertical-align">
+        <div class="col-sm-10 col-xs-12 title-container">
+            <h1>
+                Find an Agency
+            </h1>
+        </div>
+        <div class="col-sm-2 col-xs-12">
+            <a class="btn brand" href="{% url 'nc:stops-search' %}">Find a Stop</a>
+        </div>
+    </div>
+</div>
+
 <div class="agency-list-search">
     <form class="container" role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">
         <div class="row">
@@ -33,7 +46,6 @@
 {% endblock pre-content %}
 
 {% block content %}
-<h2>Agencies</h2>
 <div class="row">
     <ul>
         {% for letter, chunks in sorted_agencies %}

--- a/nc/templates/nc/agency_list.html
+++ b/nc/templates/nc/agency_list.html
@@ -1,132 +1,21 @@
-{% extends "base.html" %}
+{% extends "agency_list.html" %}
 
-{% load selectable_tags staticfiles %}
+{% block stops-search-url %}{% url 'nc:stops-search' %}{% endblock %}
 
-{% block pre-content %}
-<div class="state-banner agency-list">
-  <div class="row vertical-align">
-    <div class="col-sm-10 col-xs-12 title-container">
-      <h1>
-        Find an Agency
-      </h1>
-    </div>
-    <div class="col-sm-2 col-xs-12">
-      <a class="btn brand" href="{% url 'nc:stops-search' %}">Find a Stop</a>
-    </div>
-  </div>
-</div>
+{% block home-url %}{% url "nc:home" %}{% endblock home-url %}
 
-<div class="affix-padder"></div>
+{% block help-text %}
+  Enter an agency name into the search field above to review data on the racial
+  and ethnic demographics of people stopped, searched, and subjected to force
+  in the course of traffic stops in a given jurisdiction. Data is available
+  for most North Carolina departments and officers serving populations greater
+  than 10,000. North Carolina law requires all such agencies to report their
+  data on a monthly basis to the NC Department of Justice; however, some
+  datasets are incomplete or remain unreported. Where data sets are incomplete
+  or missing from the website, it is because they have not been reported to
+  the state agency from which the site derives its records. Open Data Policing
+  does not have access to, nor does it publish, the names of officers, drivers,
+  or passengers involved in traffic stops.
+{% endblock help-text %}
 
-<div class="agency-list-search" id="agency-list-search">
-  <form class="container" role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">
-    <div class="row">
-      <div class="col-md-8 col-md-offset-2">
-        <div class="form-group">
-        {% csrf_token %}
-          <div class="input-group">
-          {{ agency_form.agency }}
-          <span class="input-group-btn">
-            <button class="btn btn-primary" type="button">View</button>
-          </span>
-          </div><!-- /input-group -->
-        {% if agency_form.agency.errors %}
-          <div class="alert alert-warning alert-dismissible">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <ul>
-            {% for error in agency_form.agency.errors %}
-              <li><strong>{{ error }}</strong></li>
-            {% endfor %}
-            </ul>
-          </div>
-        {% endif %}
-        </div>
-      </div>
-    </div>
-  </form>
-</div>
-{% endblock pre-content %}
-
-{% block content %}
-<div class="row">
-  <div class="col-xs-12">
-    <p class="agency-list-help-block">
-      Enter an agency name into the search field above to review data on the racial
-      and ethnic demographics of people stopped, searched, and subjected to force
-      in the course of traffic stops in a given jurisdiction. Data is available
-      for most North Carolina departments and officers serving populations greater
-      than 10,000. North Carolina law requires all such agencies to report their
-      data on a monthly basis to the NC Department of Justice; however, some
-      datasets are incomplete or remain unreported. Where data sets are incomplete
-      or missing from the website, it is because they have not been reported to
-      the state agency from which the site derives its records. Open Data Policing
-      does not have access to, nor does it publish, the names of officers, drivers,
-      or passengers involved in traffic stops.
-    </p>
-  </div>
-</div>
-
-<div class="row">
-  {% for letter, chunks in sorted_agencies %}
-    <h1 class="headline">{{ letter }}</h1>
-    <div class="row">
-      {% for chunk in chunks %}
-        <div class="col-md-4 col-sm-12">
-          {% for agency in chunk %}
-            <div class="agency-link-container">
-              <a href="{% url "nc:agency-detail" agency.pk %}">
-                {{ agency }}
-              </a>
-            </div>
-          {% endfor %}
-        </div>
-      {% endfor %}
-    </div>
-  {% endfor %}
-</div>
-{% endblock %}
-
-{% block extra-css %}
-  {% include_ui_theme %}
-  {{ agency_form.media.css }}
-{% endblock %}
-
-{% block extra-js %}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
-  {{ agency_form.media.js }}
-  <script type="text/javascript">
-    $(document).ready(function() {
-    var quick_search = $('#agency_search :input[name=agency_0]');
-    quick_search.bind('djselectableselect', function(event, ui) {
-      $(this).parents("form").submit();
-    });
-    });
-  </script>
-
-  <script type="text/javascript">
-    $(function ($) {
-      var $padder = $('.affix-padder');
-      var $agencyListSearch = $('#agency-list-search');
-      var BREAKPOINT = 770;
-
-      if ($(window).width() > BREAKPOINT) {
-        $agencyListSearch.affix({
-          offset: {
-            top: function () {
-              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
-            },
-            bottom: function () {
-              return $('.footer').outerHeight(true);
-            }
-          }
-        })
-        .on('affixed.bs.affix', function () {
-          $padder.height($agencyListSearch.outerHeight());
-        })
-        .on('affixed-top.bs.affix', function () {
-          $padder.height(0);
-        });
-      }
-    });
-  </script>
-{% endblock %}
+{% block agency-link %}{% url "nc:agency-detail" agency.pk %}{% endblock agency-link %}

--- a/nc/templates/nc/agency_list.html
+++ b/nc/templates/nc/agency_list.html
@@ -4,84 +4,129 @@
 
 {% block pre-content %}
 <div class="state-banner agency-list">
-    <div class="row vertical-align">
-        <div class="col-sm-10 col-xs-12 title-container">
-            <h1>
-                Find an Agency
-            </h1>
-        </div>
-        <div class="col-sm-2 col-xs-12">
-            <a class="btn brand" href="{% url 'nc:stops-search' %}">Find a Stop</a>
-        </div>
+  <div class="row vertical-align">
+    <div class="col-sm-10 col-xs-12 title-container">
+      <h1>
+        Find an Agency
+      </h1>
     </div>
+    <div class="col-sm-2 col-xs-12">
+      <a class="btn brand" href="{% url 'nc:stops-search' %}">Find a Stop</a>
+    </div>
+  </div>
 </div>
 
-<div class="agency-list-search">
-    <form class="container" role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">
-        <div class="row">
-            <div class="col-md-8 col-md-offset-2">
-                <div class="form-group">
-                {% csrf_token %}
-                  <div class="input-group">
-                    {{ agency_form.agency }}
-                    <span class="input-group-btn">
-                      <button class="btn btn-primary" type="button">View</button>
-                    </span>
-                  </div><!-- /input-group -->
-                {% if agency_form.agency.errors %}
-                    <div class="alert alert-warning alert-dismissible">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <ul>
-                        {% for error in agency_form.agency.errors %}
-                            <li><strong>{{ error }}</strong></li>
-                        {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-                </div>
-            </div>
+<div class="affix-padder"></div>
+
+<div class="agency-list-search" id="agency-list-search">
+  <form class="container" role="form" id="agency_search" action='{% url "nc:home" %}' method="get" accept-charset="utf-8">
+    <div class="row">
+      <div class="col-md-8 col-md-offset-2">
+        <div class="form-group">
+        {% csrf_token %}
+          <div class="input-group">
+          {{ agency_form.agency }}
+          <span class="input-group-btn">
+            <button class="btn btn-primary" type="button">View</button>
+          </span>
+          </div><!-- /input-group -->
+        {% if agency_form.agency.errors %}
+          <div class="alert alert-warning alert-dismissible">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <ul>
+            {% for error in agency_form.agency.errors %}
+              <li><strong>{{ error }}</strong></li>
+            {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
         </div>
-    </form>
+      </div>
+    </div>
+  </form>
 </div>
 {% endblock pre-content %}
 
 {% block content %}
 <div class="row">
-    <ul>
-        {% for letter, chunks in sorted_agencies %}
-            <h1 class="headline">{{ letter }}</h1>
-            <div class="row">
-                {% for chunk in chunks %}
-                    <div class="col-md-4 col-sm-12">
-                        {% for agency in chunk %}
-                            <div class="agency-link-container">
-                                <a href="{% url "nc:agency-detail" agency.pk %}">
-                                    {{ agency }}
-                                </a>
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% endfor %}
+  <div class="col-xs-12">
+    <p class="agency-list-help-block">
+      Enter an agency name into the search field above to review data on the racial
+      and ethnic demographics of people stopped, searched, and subjected to force
+      in the course of traffic stops in a given jurisdiction. Data is available
+      for most North Carolina departments and officers serving populations greater
+      than 10,000. North Carolina law requires all such agencies to report their
+      data on a monthly basis to the NC Department of Justice; however, some
+      datasets are incomplete or remain unreported. Where data sets are incomplete
+      or missing from the website, it is because they have not been reported to
+      the state agency from which the site derives its records. Open Data Policing
+      does not have access to, nor does it publish, the names of officers, drivers,
+      or passengers involved in traffic stops.
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  {% for letter, chunks in sorted_agencies %}
+    <h1 class="headline">{{ letter }}</h1>
+    <div class="row">
+      {% for chunk in chunks %}
+        <div class="col-md-4 col-sm-12">
+          {% for agency in chunk %}
+            <div class="agency-link-container">
+              <a href="{% url "nc:agency-detail" agency.pk %}">
+                {{ agency }}
+              </a>
             </div>
-        {% endfor %}
-    </ul>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
 </div>
 {% endblock %}
 
 {% block extra-css %}
-    {% include_ui_theme %}
-    {{ agency_form.media.css }}
+  {% include_ui_theme %}
+  {{ agency_form.media.css }}
 {% endblock %}
 
 {% block extra-js %}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
-    {{ agency_form.media.js }}
-    <script type="text/javascript">
-      $(document).ready(function() {
-        var quick_search = $('#agency_search :input[name=agency_0]');
-        quick_search.bind('djselectableselect', function(event, ui) {
-            $(this).parents("form").submit();
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
+  {{ agency_form.media.js }}
+  <script type="text/javascript">
+    $(document).ready(function() {
+    var quick_search = $('#agency_search :input[name=agency_0]');
+    quick_search.bind('djselectableselect', function(event, ui) {
+      $(this).parents("form").submit();
+    });
+    });
+  </script>
+
+  <script type="text/javascript">
+    $(function ($) {
+      var $padder = $('.affix-padder');
+      var $agencyListSearch = $('#agency-list-search');
+      var BREAKPOINT = 770;
+
+      if ($(window).width() > BREAKPOINT) {
+        $agencyListSearch.affix({
+          offset: {
+            top: function () {
+              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
+            },
+            bottom: function () {
+              return $('.footer').outerHeight(true);
+            }
+          }
+        })
+        .on('affixed.bs.affix', function () {
+          $padder.height($agencyListSearch.outerHeight());
+        })
+        .on('affixed-top.bs.affix', function () {
+          $padder.height(0);
         });
-      });
-    </script>
+      }
+    });
+  </script>
 {% endblock %}

--- a/nc/templates/nc/agency_list.html
+++ b/nc/templates/nc/agency_list.html
@@ -4,8 +4,21 @@
 <h2>Agencies</h2>
 <div class="row">
     <ul>
-        {% for agency in object_list %}
-        <li><a href="{% url "nc:agency-detail" agency.pk %}">{{ agency }}</a></li>
+        {% for letter, chunks in sorted_agencies %}
+            <h1 class="headline">{{ letter }}</h1>
+            <div class="row">
+                {% for chunk in chunks %}
+                    <div class="col-md-4 col-sm-12">
+                        {% for agency in chunk %}
+                            <div class="agency-link-container">
+                                <a href="{% url "nc:agency-detail" agency.pk %}">
+                                    {{ agency }}
+                                </a>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+            </div>
         {% endfor %}
     </ul>
 </div>

--- a/nc/tests/test_api.py
+++ b/nc/tests/test_api.py
@@ -6,12 +6,16 @@ import pytz
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from nc.models import Agency, PURPOSE_CHOICES, RACE_CHOICES
+from nc.models import Agency, Stop, PURPOSE_CHOICES, RACE_CHOICES
 from nc.tests import factories
 from nc.api import GROUPS
 
 
 class AgencyTests(APITestCase):
+
+    def tearDown(self):
+        Stop.objects.all().delete()
+        Agency.objects.all().delete()
 
     def test_list_agencies(self):
         """Test Agency list"""

--- a/nc/tests/test_api.py
+++ b/nc/tests/test_api.py
@@ -6,16 +6,13 @@ import pytz
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from nc.models import Agency, Stop, PURPOSE_CHOICES, RACE_CHOICES
+from nc.models import Agency, PURPOSE_CHOICES, RACE_CHOICES
 from nc.tests import factories
 from nc.api import GROUPS
 
 
 class AgencyTests(APITestCase):
-
-    def tearDown(self):
-        Stop.objects.all().delete()
-        Agency.objects.all().delete()
+    multi_db = True
 
     def test_list_agencies(self):
         """Test Agency list"""

--- a/nc/tests/test_views.py
+++ b/nc/tests/test_views.py
@@ -1,12 +1,10 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from nc.models import Agency, Stop
+from nc.models import Agency
 
 
 class ViewTests(TestCase):
-    def tearDown(self):
-        Stop.objects.all().delete()
-        Agency.objects.all().delete()
+    multi_db = True
 
     def test_home(self):
         response = self.client.get(reverse('nc:home'))

--- a/nc/tests/test_views.py
+++ b/nc/tests/test_views.py
@@ -1,9 +1,13 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from nc.models import Agency
+from nc.models import Agency, Stop
 
 
 class ViewTests(TestCase):
+    def tearDown(self):
+        Stop.objects.all().delete()
+        Agency.objects.all().delete()
+
     def test_home(self):
         response = self.client.get(reverse('nc:home'))
         self.assertEqual(200, response.status_code)
@@ -16,3 +20,48 @@ class ViewTests(TestCase):
         agency = Agency.objects.create(name="Durham")
         response = self.client.get(reverse('nc:agency-detail', args=[agency.pk]))
         self.assertEqual(200, response.status_code)
+
+    def test_agency_list(self):
+        response = self.client.get(reverse('nc:agency-list'))
+        self.assertEqual(200, response.status_code)
+
+    def test_agency_list_sorted_agencies(self):
+        """
+        Verify that agencies are delivered in an appropriately sorted and
+        chunked form.
+        """
+        Agency.objects.create(name="Abc")
+        Agency.objects.create(name="Def")
+        Agency.objects.create(name="Ghi")
+        Agency.objects.create(name="Abc_")
+        Agency.objects.create(name="Def_")
+        Agency.objects.create(name="Ghi_")
+        Agency.objects.create(name="Abc__")
+        Agency.objects.create(name="Def__")
+        Agency.objects.create(name="Ghi__")
+        Agency.objects.create(name="Abc___")
+        Agency.objects.create(name="Def___")
+        Agency.objects.create(name="Ghi___")
+        Agency.objects.create(name="Abc____")
+        Agency.objects.create(name="Def____")
+        Agency.objects.create(name="Ghi____")
+
+        response = self.client.get(reverse('nc:agency-list'))
+        sorted_agencies = response.context['sorted_agencies']
+
+        # Verify that there are three alphabetic categories
+        self.assertEqual(3, len(sorted_agencies))
+
+        keys = [pair[0] for pair in sorted_agencies]
+        # Verify that the relevant letters are in there
+        self.assertTrue("A" in keys)
+        self.assertTrue("D" in keys)
+        self.assertTrue("G" in keys)
+
+        # Verify that each alphabetic category contains three chunks
+        # with the appropriate number of pieces (i.e. 2, 2, 1)
+        for (letter, chunks) in sorted_agencies:
+            self.assertEqual(3, len(chunks))
+            self.assertEqual(2, len(chunks[0]))
+            self.assertEqual(2, len(chunks[1]))
+            self.assertEqual(1, len(chunks[2]))

--- a/nc/tests/test_views.py
+++ b/nc/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from nc.models import Agency
+from nc.tests import factories
 
 
 class ViewTests(TestCase):
@@ -15,7 +16,7 @@ class ViewTests(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_agency_detail(self):
-        agency = Agency.objects.create(name="Durham")
+        agency = factories.AgencyFactory(name="Durham")
         response = self.client.get(reverse('nc:agency-detail', args=[agency.pk]))
         self.assertEqual(200, response.status_code)
 
@@ -28,21 +29,21 @@ class ViewTests(TestCase):
         Verify that agencies are delivered in an appropriately sorted and
         chunked form.
         """
-        Agency.objects.create(name="Abc")
-        Agency.objects.create(name="Def")
-        Agency.objects.create(name="Ghi")
-        Agency.objects.create(name="Abc_")
-        Agency.objects.create(name="Def_")
-        Agency.objects.create(name="Ghi_")
-        Agency.objects.create(name="Abc__")
-        Agency.objects.create(name="Def__")
-        Agency.objects.create(name="Ghi__")
-        Agency.objects.create(name="Abc___")
-        Agency.objects.create(name="Def___")
-        Agency.objects.create(name="Ghi___")
-        Agency.objects.create(name="Abc____")
-        Agency.objects.create(name="Def____")
-        Agency.objects.create(name="Ghi____")
+        factories.AgencyFactory(name="Abc")
+        factories.AgencyFactory(name="Def")
+        factories.AgencyFactory(name="Ghi")
+        factories.AgencyFactory(name="Abc_")
+        factories.AgencyFactory(name="Def_")
+        factories.AgencyFactory(name="Ghi_")
+        factories.AgencyFactory(name="Abc__")
+        factories.AgencyFactory(name="Def__")
+        factories.AgencyFactory(name="Ghi__")
+        factories.AgencyFactory(name="Abc___")
+        factories.AgencyFactory(name="Def___")
+        factories.AgencyFactory(name="Ghi___")
+        factories.AgencyFactory(name="Abc____")
+        factories.AgencyFactory(name="Def____")
+        factories.AgencyFactory(name="Ghi____")
 
         response = self.client.get(reverse('nc:agency-list'))
         sorted_agencies = response.context['sorted_agencies']

--- a/nc/tests/test_views.py
+++ b/nc/tests/test_views.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from nc.models import Agency
 from nc.tests import factories
 
 

--- a/nc/urls.py
+++ b/nc/urls.py
@@ -9,7 +9,7 @@ router.register(r'agency', api.AgencyViewSet, base_name="agency-api")
 
 
 urlpatterns = [  # noqa
-    url(r'^$', views.home, name='home'),
+    url(r'^$', views.Home.as_view(), name='home'),
     url(r'^search/$', views.search, name='stops-search'),
     url(r'^agency/$', views.AgencyList.as_view(), name='agency-list'),
     url(r'^agency/(?P<pk>\d+)/$', views.AgencyDetail.as_view(),

--- a/nc/views.py
+++ b/nc/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect, Http404
 from django.views.generic import ListView, DetailView
 from .models import Stop, Agency, Person
 from . import forms
-import math
+from traffic_stops.utils import get_chunks
 
 
 def home(request):
@@ -36,15 +36,6 @@ def search(request):
         'people': people,
     }
     return render(request, 'nc/search.html', context)
-
-
-def get_chunks(xs, chunk_count=3):
-    """
-    Helper function to split a list into roughly equally sized chunks.
-    """
-    chunk_width = math.ceil(len(xs) / chunk_count)
-    ranges = range(0, len(xs), chunk_width)
-    return [xs[x:x + chunk_width] for x in ranges]
 
 
 class AgencyList(ListView):

--- a/nc/views.py
+++ b/nc/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, redirect, Http404
 from django.views.generic import ListView, DetailView
 from .models import Stop, Agency, Person
 from . import forms
+import math
 
 
 def home(request):
@@ -37,8 +38,39 @@ def search(request):
     return render(request, 'nc/search.html', context)
 
 
+def get_chunks(xs, chunk_count=3):
+    """
+    Helper function to split a list into roughly equally sized chunks.
+    """
+    chunk_width = math.ceil(len(xs) / chunk_count)
+    ranges = range(0, len(xs), chunk_width)
+    return [xs[x:x + chunk_width] for x in ranges]
+
+
 class AgencyList(ListView):
     model = Agency
+
+    def get_context_data(self, **kwargs):
+        context = super(AgencyList, self).get_context_data(**kwargs)
+
+        # Once we have the "letters present", we want to be able to iterate
+        # over categorized, sorted lists of agencies. Therefore we create
+        # a dict indexed by first letter.
+        sorted_agencies = {}
+
+        for agency in context['agency_list']:
+            initial = agency.name[:1]
+            if initial not in sorted_agencies:
+                sorted_agencies[initial] = []
+            sorted_agencies[initial].append(agency)
+
+        for key in sorted_agencies:
+            sorted_agencies[key].sort(key=lambda x: x.name)
+            sorted_agencies[key] = get_chunks(sorted_agencies[key])
+
+        sorted_agencies = sorted(sorted_agencies.items())
+
+        return dict(context, **{"sorted_agencies": sorted_agencies, })
 
 
 class AgencyDetail(DetailView):

--- a/nc/views.py
+++ b/nc/views.py
@@ -53,6 +53,14 @@ class AgencyList(ListView):
     def get_context_data(self, **kwargs):
         context = super(AgencyList, self).get_context_data(**kwargs)
 
+        if self.request.method == 'GET' and self.request.GET:
+            form = forms.AgencySearchForm(request.GET)
+            if form.is_valid():
+                agency = form.cleaned_data['agency']
+                return redirect('nc:agency-detail', agency.pk)
+        else:
+            form = forms.AgencySearchForm()
+
         # Once we have the "letters present", we want to be able to iterate
         # over categorized, sorted lists of agencies. Therefore we create
         # a dict indexed by first letter.
@@ -70,7 +78,8 @@ class AgencyList(ListView):
 
         sorted_agencies = sorted(sorted_agencies.items())
 
-        return dict(context, **{"sorted_agencies": sorted_agencies, })
+        return dict(context, **{"sorted_agencies": sorted_agencies,
+                                "agency_form": form, })
 
 
 class AgencyDetail(DetailView):

--- a/nc/views.py
+++ b/nc/views.py
@@ -54,7 +54,7 @@ class AgencyList(ListView):
         context = super(AgencyList, self).get_context_data(**kwargs)
 
         if self.request.method == 'GET' and self.request.GET:
-            form = forms.AgencySearchForm(request.GET)
+            form = forms.AgencySearchForm(self.request.GET)
             if form.is_valid():
                 agency = form.cleaned_data['agency']
                 return redirect('nc:agency-detail', agency.pk)

--- a/nc/views.py
+++ b/nc/views.py
@@ -1,20 +1,22 @@
 from django.shortcuts import render, redirect, Http404
-from django.views.generic import ListView, DetailView
+from django.views.generic import ListView, DetailView, TemplateView
+from django.views.generic.edit import ProcessFormView, FormMixin
 from .models import Stop, Agency, Person
 from . import forms
 from traffic_stops.utils import get_chunks
+from collections import defaultdict
 
 
-def home(request):
-    if request.method == 'GET' and request.GET:
-        form = forms.AgencySearchForm(request.GET)
-        if form.is_valid():
-            agency = form.cleaned_data['agency']
-            return redirect('nc:agency-detail', agency.pk)
-    else:
-        form = forms.AgencySearchForm()
-    context = {'agency_form': form}
-    return render(request, 'nc.html', context)
+class Home(FormMixin, ProcessFormView, TemplateView):
+    form_class = forms.AgencySearchForm
+    template_name = 'nc.html'
+
+    def get(self, request, *args, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                return redirect('nc:agency-detail', form.cleaned_data['agency'].pk)
+        return super(Home, self).get(request, **kwargs)
 
 
 def search(request):
@@ -38,29 +40,39 @@ def search(request):
     return render(request, 'nc/search.html', context)
 
 
-class AgencyList(ListView):
+class AgencyList(FormMixin, ListView):
     model = Agency
+    form_class = forms.AgencySearchForm
+    success_url = 'nc:agency-detail'
+
+    def get_success_url(self, pk, **kwargs):
+        success = self.get_success_url()
+        return redirect(success, pk)
+
+    def get(self, request, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                return self.get_success_url(pk=form.cleaned_data['agency'].pk)
+        return super(AgencyList, self).get(request, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(AgencyList, self).get_context_data(**kwargs)
 
-        if self.request.method == 'GET' and self.request.GET:
-            form = forms.AgencySearchForm(self.request.GET)
-            if form.is_valid():
-                agency = form.cleaned_data['agency']
-                return redirect('nc:agency-detail', agency.pk)
-        else:
-            form = forms.AgencySearchForm()
+        # The following seems to be all ProcessFormView really gives us.
+        # It causes collisions with ListView's get method. Hence
+        # we just add it as a trivial context-modification snippet.
+        form_class = self.get_form_class()
+        form = self.get_form(form_class)
+        context['form'] = form
 
         # Once we have the "letters present", we want to be able to iterate
         # over categorized, sorted lists of agencies. Therefore we create
         # a dict indexed by first letter.
-        sorted_agencies = {}
+        sorted_agencies = defaultdict(list)
 
         for agency in context['agency_list']:
             initial = agency.name[:1]
-            if initial not in sorted_agencies:
-                sorted_agencies[initial] = []
             sorted_agencies[initial].append(agency)
 
         for key in sorted_agencies:
@@ -69,8 +81,10 @@ class AgencyList(ListView):
 
         sorted_agencies = sorted(sorted_agencies.items())
 
-        return dict(context, **{"sorted_agencies": sorted_agencies,
-                                "agency_form": form, })
+        context['sorted_agencies'] = sorted_agencies
+        context['agency_form'] = form
+
+        return context
 
 
 class AgencyDetail(DetailView):

--- a/traffic_stops/base_views.py
+++ b/traffic_stops/base_views.py
@@ -1,0 +1,80 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.shortcuts import redirect, Http404
+from django.views.generic import DetailView, ListView, TemplateView
+from django.views.generic.edit import ProcessFormView, FormMixin
+from traffic_stops.utils import get_chunks
+from collections import defaultdict
+
+
+class Home(FormMixin, ProcessFormView, TemplateView):
+    def get(self, request, *args, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                success = self.get_success_url()
+                return redirect(success, form.cleaned_data['agency'].pk)
+        return super(Home, self).get(request, **kwargs)
+
+
+class AgencyList(FormMixin, ListView):
+    def get_success_url(self, pk, **kwargs):
+        success = super(AgencyList, self).get_success_url(self, **kwargs)
+        return redirect(success, pk)
+
+    def get(self, request, **kwargs):
+        if request.GET:
+            form = self.get_form_class()(request.GET)
+            if form.is_valid():
+                return self.get_success_url(pk=form.cleaned_data['agency'].pk)
+        return super(AgencyList, self).get(request, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(AgencyList, self).get_context_data(**kwargs)
+
+        # The following seems to be all ProcessFormView really gives us.
+        # It causes collisions with ListView's get method. Hence
+        # we just add it as a trivial context-modification snippet.
+        form_class = self.get_form_class()
+        form = self.get_form(form_class)
+        context['form'] = form
+
+        # Once we have the "letters present", we want to be able to iterate
+        # over categorized, sorted lists of agencies. Therefore we create
+        # a dict indexed by first letter.
+        sorted_agencies = defaultdict(list)
+
+        for agency in context['agency_list']:
+            initial = agency.name[:1]
+            sorted_agencies[initial].append(agency)
+
+        for key in sorted_agencies:
+            sorted_agencies[key].sort(key=lambda x: x.name)
+            sorted_agencies[key] = get_chunks(sorted_agencies[key])
+
+        sorted_agencies = sorted(sorted_agencies.items())
+
+        context['sorted_agencies'] = sorted_agencies
+        context['agency_form'] = form
+
+        return context
+
+
+class AgencyDetail(DetailView):
+    def get_stop_model(self):
+        if self.stop_model:
+            return self.stop_model
+        else:
+            raise ImproperlyConfigured("No stop model provided.")
+
+    def get_context_data(self, **kwargs):
+        context = super(AgencyDetail, self).get_context_data(**kwargs)
+        agency = context['object']
+        officer_id = self.request.GET.get('officer_id')
+
+        if officer_id:
+            Stop = self.get_stop_model()
+            if not Stop.objects.filter(agency=agency, officer_id=officer_id).exists():
+                raise Http404()
+            context['officer_id'] = officer_id
+
+        return context

--- a/traffic_stops/settings/dev.py
+++ b/traffic_stops/settings/dev.py
@@ -30,3 +30,6 @@ if 'test' in sys.argv:
         'django.contrib.auth.hashers.SHA1PasswordHasher',
         'django.contrib.auth.hashers.MD5PasswordHasher',
     )
+    CACHES['cache_machine'] = {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }

--- a/traffic_stops/static/js/affix.js
+++ b/traffic_stops/static/js/affix.js
@@ -1,0 +1,41 @@
+import $ from 'jquery';
+
+$(function ($) {
+  var $padder = $('.affix-padder');
+  var $affixEl = $('.affix-element');
+  var BREAKPOINT = 770;
+  var $offsetTopPos, $offsetTopNeg, $offsetBottom;
+
+  if ($(window).width() > BREAKPOINT && $affixEl.length > 0) {
+    $offsetTopPos = $('.affix-offset-top-pos');
+    $offsetTopNeg = $('.affix-offset-top-neg');
+    $offsetBottom = $('.affix-offset-bottom');
+
+    $affixEl.affix({
+      offset: {
+        top: function () {
+          var offsetTopPos = 0, offsetTopNeg = 0;
+
+          $offsetTopPos.each(function () {
+            offsetTopPos += $(this).outerHeight();
+          });
+
+          $offsetTopNeg.each(function () {
+            offsetTopNeg += $(this).innerHeight();
+          })
+
+          return offsetTopPos - offsetTopNeg;
+        },
+        bottom: function () {
+          return $offsetBottom.outerHeight(true);
+        }
+      }
+    })
+    .on('affixed.bs.affix', function () {
+      $padder.height($affixEl.outerHeight());
+    })
+    .on('affixed-top.bs.affix', function () {
+      $padder.height(0);
+    });
+  }
+});

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -55,11 +55,11 @@ var CensusRatioDonut = VisualBase.extend({
     nv.addGraph(() => {
       d3.select(this.svg[0])
           .datum(data)
-        .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")
           .style({ width:  `${this.get('width')}px`
                  , height: `${this.get('height')}px` })
+        .transition().duration(1200)
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);

--- a/traffic_stops/static/js/index.js
+++ b/traffic_stops/static/js/index.js
@@ -16,3 +16,4 @@ window.log = function f(){ log.history = log.history || []; log.history.push(arg
 
 require('./app/states/nc');
 require('./app/states/md');
+require('./affix');

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -471,9 +471,9 @@ h2.officer {
 /***
  * To accommodate the extra padding added to anchor elements without breaking
  * the accessibility of controls (see `fixAnchorElements in base
- * agency_detail.html), we hide overflow in rows.
+ * agency_detail.html), we hide overflow in containers.
  */
-.row {
+.container {
   overflow: hidden;
 }
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -252,7 +252,7 @@ code {
   }
 
   &.agency-list {
-    padding: 90px 40px 60px 40px;
+    padding: 90px 40px 50px 40px;
   }
 
   h1 {
@@ -295,7 +295,7 @@ code {
 
       .title-container {
         margin-bottom: 20px;
-        padding: 0 30px;
+        padding: 0 30px 6px 30px;
         border-bottom: 1px solid white;
       }
 
@@ -408,8 +408,14 @@ h1.headline {
 .agency-list-search {
   background-color: #f8f8f8;
 
+  &.affix {
+    z-index: 1024;
+    width: 100%;
+    top: 50px;
+  }
+
   .form-group {
-    margin-top: 20px;
+    margin: 20px 0;
   }
 
   .input-group {
@@ -421,6 +427,13 @@ h1.headline {
       height: 39px;
     }
   }
+}
+
+.agency-list-help-block {
+  color: @gray-light;
+  font-size: 16px;
+  line-height: 1.5;
+  margin-top: 20px;
 }
 
 /* Agency detail page

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -383,6 +383,20 @@ body#state {
   }
 }
 
+/* Agency list page
+========================================= */
+
+h1.headline {
+  padding: 20px 30px 20px 50px;
+  font-size: 40px;
+  margin-left: -20px;
+}
+
+.agency-link-container {
+  padding: 10px 0;
+  font-size: 16px;
+}
+
 /* Agency detail page
 ========================================= */
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -471,9 +471,9 @@ h2.officer {
 /***
  * To accommodate the extra padding added to anchor elements without breaking
  * the accessibility of controls (see `fixAnchorElements in base
- * agency_detail.html), we hide overflow in containers.
+ * agency_detail.html), we hide overflow in agency detail containers.
  */
-.container {
+.container.agency-detail {
   overflow: hidden;
 }
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -349,7 +349,7 @@ code {
   }
 }
 
-p.nc-agency-intro {
+p.agency-intro {
   margin: 20px 0;
 }
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -141,6 +141,10 @@ code {
   border-bottom: 0;
 }
 
+.navbar-fixed-top + * {
+  padding-top: 50px;
+}
+
 .navbar-default {
   .navbar-brand {
     font-weight: bold;
@@ -395,6 +399,24 @@ h1.headline {
 .agency-link-container {
   padding: 10px 0;
   font-size: 16px;
+}
+
+.agency-list-search {
+  background-color: #f8f8f8;
+
+  .form-group {
+    margin-top: 20px;
+  }
+
+  .input-group {
+    * {
+      font-size: 18px;
+    }
+
+    input {
+      height: 39px;
+    }
+  }
 }
 
 /* Agency detail page

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -251,6 +251,10 @@ code {
     padding: 70px 40px 60px 40px;
   }
 
+  &.agency-list {
+    padding: 90px 40px 60px 40px;
+  }
+
   h1 {
     color: white;
     margin-top: 0;

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -8,7 +8,7 @@
 
 {% block content-outer %}
 
-<div class="state-banner agency-detail{% if officer_id %} officer{% endif %}">
+<div class="state-banner affix-offset-top-pos agency-detail{% if officer_id %} officer{% endif %}">
   <div class="row vertical-align">
     <div class="col-xs-12">
       <a class="back" href="{% block agency-list-url %}{% endblock %}">◀ Back to "Find An Agency"</a>
@@ -29,7 +29,7 @@
   </div>
 </div>
 
-<nav class="graphs-nav" id="graphs-nav">
+<nav class="graphs-nav affix-element" id="graphs-nav">
   <ul class="nav">
     {% block census-link %}{% endblock census-link %}
     <li><a href="#stop-percentage">Traffic Stops</a></li>
@@ -72,33 +72,13 @@
 
       var $body = $('body');
       var $window = $(window);
-      var $padder = $('.affix-padder');
       var $graphsNav = $('#graphs-nav');
       var BREAKPOINT = 770;
 
       $body.scrollspy({ target: '#graphs-nav', offset: 50 });
-      $('window').on('load', function () {
+      $window.on('load', function () {
         $body.scrollspy('refresh');
       });
-
-      if ($window.width() > BREAKPOINT) {
-        $graphsNav.affix({
-          offset: {
-            top: function () {
-              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
-            },
-            bottom: function () {
-              return $('.footer').outerHeight(true);
-            }
-          }
-        })
-        .on('affixed.bs.affix', function () {
-          $padder.height($graphsNav.outerHeight());
-        })
-        .on('affixed-top.bs.affix', function () {
-          $padder.height(0);
-        });
-      }
 
       (function fixAnchorElements () {
         var $anchors = $('.headline > h2');

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -40,7 +40,7 @@
 
 <div class="affix-padder"></div>
 
-<div class="container">
+<div class="container agency-detail">
   <div class="row">
     <div class="col-md-12" role="main">
       {% block census-display %}{% endblock census-display %}

--- a/traffic_stops/templates/agency_list.html
+++ b/traffic_stops/templates/agency_list.html
@@ -3,7 +3,7 @@
 {% load selectable_tags staticfiles %}
 
 {% block pre-content %}
-<div class="state-banner agency-list">
+<div class="state-banner affix-offset-top-pos agency-list">
   <div class="row vertical-align">
     <div class="col-sm-10 col-xs-12 title-container">
       <h1>
@@ -18,7 +18,7 @@
 
 <div class="affix-padder"></div>
 
-<div class="agency-list-search" id="agency-list-search">
+<div class="agency-list-search affix-element" id="agency-list-search">
   <form class="container" role="form" id="agency_search" action='{% block home-url %}{% endblock home-url %}' method="get" accept-charset="utf-8">
     <div class="row">
       <div class="col-md-8 col-md-offset-2">
@@ -91,33 +91,6 @@
     quick_search.bind('djselectableselect', function(event, ui) {
       $(this).parents("form").submit();
     });
-    });
-  </script>
-
-  <script type="text/javascript">
-    $(function ($) {
-      var $padder = $('.affix-padder');
-      var $agencyListSearch = $('#agency-list-search');
-      var BREAKPOINT = 770;
-
-      if ($(window).width() > BREAKPOINT) {
-        $agencyListSearch.affix({
-          offset: {
-            top: function () {
-              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
-            },
-            bottom: function () {
-              return $('.footer').outerHeight(true);
-            }
-          }
-        })
-        .on('affixed.bs.affix', function () {
-          $padder.height($agencyListSearch.outerHeight());
-        })
-        .on('affixed-top.bs.affix', function () {
-          $padder.height(0);
-        });
-      }
     });
   </script>
 {% endblock %}

--- a/traffic_stops/templates/agency_list.html
+++ b/traffic_stops/templates/agency_list.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% load selectable_tags staticfiles %}
+
+{% block pre-content %}
+<div class="state-banner agency-list">
+  <div class="row vertical-align">
+    <div class="col-sm-10 col-xs-12 title-container">
+      <h1>
+        Find an Agency
+      </h1>
+    </div>
+    <div class="col-sm-2 col-xs-12">
+      <a class="btn brand" href="{% block stops-search-url %}{% endblock %}">Find a Stop</a>
+    </div>
+  </div>
+</div>
+
+<div class="affix-padder"></div>
+
+<div class="agency-list-search" id="agency-list-search">
+  <form class="container" role="form" id="agency_search" action='{% block home-url %}{% endblock home-url %}' method="get" accept-charset="utf-8">
+    <div class="row">
+      <div class="col-md-8 col-md-offset-2">
+        <div class="form-group">
+        {% csrf_token %}
+          <div class="input-group">
+          {{ agency_form.agency }}
+          <span class="input-group-btn">
+            <button class="btn btn-primary" type="button">View</button>
+          </span>
+          </div><!-- /input-group -->
+        {% if agency_form.agency.errors %}
+          <div class="alert alert-warning alert-dismissible">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <ul>
+            {% for error in agency_form.agency.errors %}
+              <li><strong>{{ error }}</strong></li>
+            {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock pre-content %}
+
+{% block content %}
+<div class="row">
+  <div class="col-xs-12">
+    <p class="agency-list-help-block">
+      {% block help-text %}
+      {% endblock %}
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  {% for letter, chunks in sorted_agencies %}
+    <h1 class="headline">{{ letter }}</h1>
+    <div class="row">
+      {% for chunk in chunks %}
+        <div class="col-md-4 col-sm-12">
+          {% for agency in chunk %}
+            <div class="agency-link-container">
+              <a href="{% block agency-link %}{% endblock agency-link %}">
+                {{ agency }}
+              </a>
+            </div>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>
+{% endblock %}
+
+{% block extra-css %}
+  {% include_ui_theme %}
+  {{ agency_form.media.css }}
+{% endblock %}
+
+{% block extra-js %}
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
+  {{ agency_form.media.js }}
+  <script type="text/javascript">
+    $(document).ready(function() {
+    var quick_search = $('#agency_search :input[name=agency_0]');
+    quick_search.bind('djselectableselect', function(event, ui) {
+      $(this).parents("form").submit();
+    });
+    });
+  </script>
+
+  <script type="text/javascript">
+    $(function ($) {
+      var $padder = $('.affix-padder');
+      var $agencyListSearch = $('#agency-list-search');
+      var BREAKPOINT = 770;
+
+      if ($(window).width() > BREAKPOINT) {
+        $agencyListSearch.affix({
+          offset: {
+            top: function () {
+              return $('.state-banner').outerHeight() - $('.odp-nav').innerHeight();
+            },
+            bottom: function () {
+              return $('.footer').outerHeight(true);
+            }
+          }
+        })
+        .on('affixed.bs.affix', function () {
+          $padder.height($agencyListSearch.outerHeight());
+        })
+        .on('affixed-top.bs.affix', function () {
+          $padder.height(0);
+        });
+      }
+    });
+  </script>
+{% endblock %}

--- a/traffic_stops/templates/agency_list.html
+++ b/traffic_stops/templates/agency_list.html
@@ -25,16 +25,16 @@
         <div class="form-group">
         {% csrf_token %}
           <div class="input-group">
-          {{ agency_form.agency }}
+          {{ form.agency }}
           <span class="input-group-btn">
             <button class="btn btn-primary" type="button">View</button>
           </span>
           </div><!-- /input-group -->
-        {% if agency_form.agency.errors %}
+        {% if form.agency.errors %}
           <div class="alert alert-warning alert-dismissible">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             <ul>
-            {% for error in agency_form.agency.errors %}
+            {% for error in form.agency.errors %}
               <li><strong>{{ error }}</strong></li>
             {% endfor %}
             </ul>
@@ -79,12 +79,12 @@
 
 {% block extra-css %}
   {% include_ui_theme %}
-  {{ agency_form.media.css }}
+  {{ form.media.css }}
 {% endblock %}
 
 {% block extra-js %}
   <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
-  {{ agency_form.media.js }}
+  {{ form.media.js }}
   <script type="text/javascript">
     $(document).ready(function() {
     var quick_search = $('#agency_search :input[name=agency_0]');

--- a/traffic_stops/templates/base.html
+++ b/traffic_stops/templates/base.html
@@ -22,6 +22,9 @@
             {% include "includes/navigation.html" %}
         {% endblock navigation %}
 
+        {% block pre-content %}
+        {% endblock pre-content %}
+
         {% block content-outer %}
         <div id="content" class="container">
             <div class="row">

--- a/traffic_stops/templates/base.html
+++ b/traffic_stops/templates/base.html
@@ -45,7 +45,7 @@
         {% endblock content-outer %}
     </div>
     {% block footer %}
-    <div id="footer">
+    <div class="affix-offset-bottom" id="footer">
       <div class="container">
         <p class="small credit">OpenDataPolicing - <a href='http://www.southerncoalition.org/'>Southern Coalition for Social Justice</a>
         - <a href="{% url "admin:index" %}">Admin</a>

--- a/traffic_stops/templates/includes/navigation.html
+++ b/traffic_stops/templates/includes/navigation.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 
-<div class="navbar navbar-default navbar-fixed-top odp-nav {% if navbar_inverse %}navbar-inverse{% endif %}" role="navigation">
+<div class="navbar navbar-default navbar-fixed-top affix-offset-top-neg odp-nav {% if navbar_inverse %}navbar-inverse{% endif %}" role="navigation">
   <div id="content" class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -57,11 +57,8 @@
 
         <div class="tab-content">
           <div class="tab-pane active" id="agencies" role="tabpanel">
-            <p class='nc-agency-intro'>
-              Review agency-level data on the racial and ethnic demographics of people
-              stopped, searched, and subjected to force in the course of traffic stops
-              in a given jurisdiction.
-            </p>
+            {% block agency-intro %}
+            {% endblock agency-intro %}
 
             {% block search-form %}
               <h4>View Agency Dashboard</h4>

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -5,12 +5,12 @@
 
 {% block extra-css %}
     {% include_ui_theme %}
-    {{ agency_form.media.css }}
+    {{ form.media.css }}
 {% endblock %}
 
 {% block extra-js %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.js"></script>
-{{ agency_form.media.js }}
+{{ form.media.js }}
 <script type="text/javascript">
   $(document).ready(function() {
     var quick_search = $('#agency_search :input[name=agency_0]');
@@ -66,16 +66,16 @@
                   <div class="form-group">
                   {% csrf_token %}
                   <div class="input-group">
-                    {{ agency_form.agency }}
+                    {{ form.agency }}
                     <span class="input-group-btn">
                       <button class="btn btn-primary" type="button">View</button>
                     </span>
                   </div><!-- /input-group -->
-                  {% if agency_form.agency.errors %}
+                  {% if form.agency.errors %}
                       <div class="alert alert-warning alert-dismissible">
                           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                           <ul>
-                          {% for error in agency_form.agency.errors %}
+                          {% for error in form.agency.errors %}
                               <li><strong>{{ error }}</strong></li>
                           {% endfor %}
                           </ul>

--- a/traffic_stops/utils.py
+++ b/traffic_stops/utils.py
@@ -1,5 +1,6 @@
 import math
 
+
 def get_chunks(xs, chunk_count=3):
     """
     Helper function to split a list into roughly equally sized chunks.

--- a/traffic_stops/utils.py
+++ b/traffic_stops/utils.py
@@ -1,0 +1,9 @@
+import math
+
+def get_chunks(xs, chunk_count=3):
+    """
+    Helper function to split a list into roughly equally sized chunks.
+    """
+    chunk_width = math.ceil(len(xs) / chunk_count)
+    ranges = range(0, len(xs), chunk_width)
+    return [xs[x:x + chunk_width] for x in ranges]


### PR DESCRIPTION
This re-implements the "Find an Agency" pages for NC and MD to match the mockups and behave as requested, to whit:

1. Match mockup
2. Divide agencies alphabetically

    The logic to divvy up agencies alphabetically lives on the back-end. It omits letters for which no agency exists. Tests have been added to verify this aggregation.
3. Give the user the option to search from the top

    This is copied rotely from the state homepage.
4. Make the search bar sticky

    Having found that the sticky header code for this and the agency detail page were mostly the same, I decided to refactor both to use a common JS module which now is imported in `index.js`.
5. Ensure this exists for MD as well as NC
6. Add a link to these pages from the state homepage
    The mockups don't specify what this should look like, so I improvised, with Katie's approval.