### PR TITLE
ODPM-65 - Provide census data if available via agency API

### DIFF
--- a/md/admin.py
+++ b/md/admin.py
@@ -3,7 +3,7 @@ from md.models import Agency
 
 
 class AgencyAdmin(admin.ModelAdmin):
-    pass
+    list_display = ('name', 'census_profile_id')
 
 
 admin.site.register(Agency, AgencyAdmin)

--- a/md/data/copy.sql
+++ b/md/data/copy.sql
@@ -23,9 +23,9 @@ COPY md_stop (stop_id, stop_date_text, stop_time_text,
 
 -- populate md_agency lookup table
 
--- while there is a CSV with MD agencies, the raw data (md_stop) could
--- have additional agencies that aren't yet in the CSV, so build the agency
--- table from the agency values in md_stop
+-- while the MD agency CSV *should* have all MD agencies, the raw data
+-- (md_stop) could have additional agencies that aren't yet in the CSV,
+-- so build the agency table from the agency values in md_stop
 INSERT INTO md_agency (name, census_profile_id) (
     SELECT DISTINCT(agency_description), '' from md_stop ORDER BY agency_description
 );

--- a/md/data/copy.sql
+++ b/md/data/copy.sql
@@ -21,9 +21,13 @@ COPY md_stop (stop_id, stop_date_text, stop_time_text,
     CSV HEADER
     FORCE NOT NULL search_conducted, search_reason, seized, stop_reason, gender, ethnicity, stop_location, purpose;
 
--- -- populate md_agency lookup table
-INSERT INTO md_agency (name) (
-    SELECT DISTINCT(agency_description) from md_stop ORDER BY agency_description
+-- populate md_agency lookup table
+
+-- while there is a CSV with MD agencies, the raw data (md_stop) could
+-- have additional agencies that aren't yet in the CSV, so build the agency
+-- table from the agency values in md_stop
+INSERT INTO md_agency (name, census_profile_id) (
+    SELECT DISTINCT(agency_description), '' from md_stop ORDER BY agency_description
 );
 
 -- populate md_stop.agency_id foreign key
@@ -32,6 +36,21 @@ FROM
    md_agency
 WHERE
    md_stop.agency_description = md_agency.name;
+
+-- update md_agency with census GEOID values from the MD agency CSV
+CREATE TEMP TABLE agency_csv_table (code TEXT, name TEXT, geoid TEXT);
+
+COPY agency_csv_table FROM :'md_csv_table' WITH
+    DELIMITER ','
+    NULL AS ''
+    CSV HEADER
+    FORCE NOT NULL code, name;
+
+UPDATE md_agency SET census_profile_id = agency_csv_table.geoid
+    FROM agency_csv_table
+    WHERE md_agency.name = agency_csv_table.name AND agency_csv_table.geoid IS NOT NULL;
+
+DROP TABLE agency_csv_table;
 
 ANALYZE;
 

--- a/md/data/importer.py
+++ b/md/data/importer.py
@@ -361,7 +361,10 @@ def run(url, destination=None, download=True):
 def copy_from(csv_path):
     """Execute copy.sql to COPY csv data files into PostgreSQL database"""
     sql_file = os.path.join(os.path.dirname(__file__), 'copy.sql')
-    md_csv_path = os.path.join(os.path.dirname(__file__), 'MD_agencies.csv')
+    md_csv_path = os.path.join(
+        os.path.dirname(__file__),
+        os.path.basename(AGENCY_MAPPING_CSV)
+    )
     cmd = ['psql',
            '-v', 'data_file={}'.format(csv_path),
            '-v', 'md_csv_table={}'.format(md_csv_path),

--- a/md/data/importer.py
+++ b/md/data/importer.py
@@ -361,8 +361,10 @@ def run(url, destination=None, download=True):
 def copy_from(csv_path):
     """Execute copy.sql to COPY csv data files into PostgreSQL database"""
     sql_file = os.path.join(os.path.dirname(__file__), 'copy.sql')
+    md_csv_path = os.path.join(os.path.dirname(__file__), 'MD_agencies.csv')
     cmd = ['psql',
            '-v', 'data_file={}'.format(csv_path),
+           '-v', 'md_csv_table={}'.format(md_csv_path),
            '-f', sql_file,
            settings.DATABASES['traffic_stops_md']['NAME']]
     if settings.DATABASE_ETL_USER:

--- a/md/migrations/0005_agency_census_profile_id.py
+++ b/md/migrations/0005_agency_census_profile_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('md', '0004_auto_20160711_2024'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='agency',
+            name='census_profile_id',
+            field=models.CharField(blank=True, max_length=16, default=''),
+        ),
+    ]

--- a/md/models.py
+++ b/md/models.py
@@ -2,9 +2,7 @@ from django.db import models
 
 from caching.base import CachingManager, CachingMixin
 
-# Columns in CSV:
-# get applicable columns from md csv
-
+from tsdata.models import CensusProfile
 
 YN_CHOICES = (
     ("Y", "Yes"),
@@ -82,6 +80,8 @@ class Stop(CachingMixin, models.Model):
 
 class Agency(CachingMixin, models.Model):
     name = models.CharField(max_length=255)
+    # link to CensusProfile (no cross-database foreign key)
+    census_profile_id = models.CharField(max_length=16, blank=True, default='')
 
     objects = CachingManager()
 
@@ -90,3 +90,11 @@ class Agency(CachingMixin, models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def census_profile(self):
+        if self.census_profile_id:
+            profile = CensusProfile.objects.get(id=self.census_profile_id)
+            return profile.get_census_dict()
+        else:
+            return dict()

--- a/md/serializers.py
+++ b/md/serializers.py
@@ -3,6 +3,9 @@ from md import models as stops
 
 
 class AgencySerializer(serializers.ModelSerializer):
+
     class Meta:
         model = stops.Agency
-        fields = ('id', 'name')
+        fields = (
+            'id', 'name', 'census_profile',
+        )

--- a/md/tests/test_api.py
+++ b/md/tests/test_api.py
@@ -8,6 +8,7 @@ from rest_framework.test import APITestCase
 
 from md.models import Agency, ETHNICITY_CHOICES, PURPOSE_CHOICES
 from md.tests import factories
+from tsdata.tests.factories import CensusProfileFactory
 
 
 class AgencyTests(APITestCase):
@@ -22,6 +23,23 @@ class AgencyTests(APITestCase):
         self.assertIn((agency.pk, agency.name), [
             (a.pk, a.name) for a in Agency.objects.all()
         ])
+
+    def test_agency_census_data(self):
+        """
+        Construct an agency with associated CensusProfile, check
+        for inclusion
+        """
+        census_profile = CensusProfileFactory()
+        agency = factories.AgencyFactory(census_profile_id=census_profile.id)
+        url = reverse('md:agency-api-detail', args=[agency.pk])
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('census_profile', response.data)
+        # CensusProfile tests check census data in more detail
+        for attr in ('hispanic', 'non_hispanic', 'total'):
+            self.assertEqual(
+                response.data['census_profile'][attr], getattr(census_profile, attr)
+            )
 
     def test_stops_api(self):
         """Test Agency stops API endpoint with no stops"""

--- a/nc/admin.py
+++ b/nc/admin.py
@@ -3,7 +3,7 @@ from nc.models import Agency
 
 
 class AgencyAdmin(admin.ModelAdmin):
-    pass
+    list_display = ('name', 'census_profile_id')
 
 
 admin.site.register(Agency, AgencyAdmin)

--- a/nc/data/NC_agencies.csv
+++ b/nc/data/NC_agencies.csv
@@ -1,0 +1,13 @@
+Agency Name,GEOID
+Asheville Police Department,16000US3702140
+Carolina Beach Police Department,16000US3710500
+Carrboro Police Department,16000US3710620
+Cary Police Department,16000US3710740
+Chapel Hill Police Department,16000US3711800
+Durham Police Department,16000US3719000
+Fuquay-Varina Police Department,16000US3725300
+Garner Police Department,16000US3725480
+Greensboro Police Department,16000US3728000
+Holly Springs Police Department,16000US3732260
+Raleigh Police Department,16000US3755000
+Washington Police Department,16000US3771220

--- a/nc/data/importer.py
+++ b/nc/data/importer.py
@@ -91,8 +91,10 @@ def convert_to_csv(destination):
 def copy_from(destination):
     """Execute copy.sql to COPY csv data files into PostgreSQL database"""
     sql_file = os.path.join(os.path.dirname(__file__), 'copy.sql')
+    nc_csv_path = os.path.join(os.path.dirname(__file__), 'NC_agencies.csv')
     cmd = ['psql',
            '-v', 'data_dir={}'.format(destination),
+           '-v', 'nc_csv_table={}'.format(nc_csv_path),
            '-f', sql_file,
            settings.DATABASES['traffic_stops_nc']['NAME']]
     if settings.DATABASE_ETL_USER:

--- a/nc/migrations/0002_agency_census_profile_id.py
+++ b/nc/migrations/0002_agency_census_profile_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nc', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='agency',
+            name='census_profile_id',
+            field=models.CharField(default='', blank=True, max_length=16),
+        ),
+    ]

--- a/nc/models.py
+++ b/nc/models.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from caching.base import CachingManager, CachingMixin
 
+from tsdata.models import CensusProfile
 
 PURPOSE_CHOICES = ((1, 'Speed Limit Violation'),
                    (2, 'Stop Light/Sign Violation'),
@@ -135,6 +136,8 @@ class SearchBasis(CachingMixin, models.Model):
 
 class Agency(CachingMixin, models.Model):
     name = models.CharField(max_length=255)
+    # link to CensusProfile (no cross-database foreign key)
+    census_profile_id = models.CharField(max_length=16, blank=True, default='')
 
     objects = CachingManager()
 
@@ -143,3 +146,11 @@ class Agency(CachingMixin, models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def census_profile(self):
+        if self.census_profile_id:
+            profile = CensusProfile.objects.get(id=self.census_profile_id)
+            return profile.get_census_dict()
+        else:
+            return dict()

--- a/nc/serializers.py
+++ b/nc/serializers.py
@@ -5,4 +5,4 @@ from nc import models as stops
 class AgencySerializer(serializers.ModelSerializer):
     class Meta:
         model = stops.Agency
-        fields = ('id', 'name')
+        fields = ('id', 'name', 'census_profile',)

--- a/nc/tests/test_api.py
+++ b/nc/tests/test_api.py
@@ -9,6 +9,7 @@ from rest_framework.test import APITestCase
 from nc.models import Agency, PURPOSE_CHOICES, RACE_CHOICES
 from nc.tests import factories
 from nc.api import GROUPS
+from tsdata.tests.factories import CensusProfileFactory
 
 
 class AgencyTests(APITestCase):
@@ -23,6 +24,23 @@ class AgencyTests(APITestCase):
         self.assertIn((agency.pk, agency.name), [
             (a.pk, a.name) for a in Agency.objects.all()
         ])
+
+    def test_agency_census_data(self):
+        """
+        Construct an agency with associated CensusProfile, check
+        for inclusion of reasonable data
+        """
+        census_profile = CensusProfileFactory()
+        agency = factories.AgencyFactory(census_profile_id=census_profile.id)
+        url = reverse('nc:agency-api-detail', args=[agency.pk])
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('census_profile', response.data)
+        # CensusProfile tests check census data in more detail
+        for attr in ('hispanic', 'non_hispanic', 'total'):
+            self.assertEqual(
+                response.data['census_profile'][attr], getattr(census_profile, attr)
+            )
 
     def test_stops_api(self):
         """Test Agency stops API endpoint with no stops"""

--- a/tsdata/models.py
+++ b/tsdata/models.py
@@ -57,3 +57,15 @@ class CensusProfile(models.Model):
 
     def __str__(self):
         return self.location
+
+    def get_census_dict(self):
+        return dict(
+            white=self.white,
+            black=self.black,
+            native_american=self.native_american,
+            asian=self.asian,
+            other=self.other + self.native_hawaiian,
+            hispanic=self.hispanic,
+            non_hispanic=self.non_hispanic,
+            total=self.total,
+        )

--- a/tsdata/models.py
+++ b/tsdata/models.py
@@ -64,7 +64,7 @@ class CensusProfile(models.Model):
             black=self.black,
             native_american=self.native_american,
             asian=self.asian,
-            other=self.other + self.native_hawaiian,
+            other=self.other + self.native_hawaiian + self.two_or_more_races,
             hispanic=self.hispanic,
             non_hispanic=self.non_hispanic,
             total=self.total,

--- a/tsdata/tests/factories.py
+++ b/tsdata/tests/factories.py
@@ -1,0 +1,40 @@
+import factory
+import factory.fuzzy
+import math
+
+from tsdata import models
+
+
+class CensusProfileFactory(factory.django.DjangoModelFactory):
+
+    class Meta(object):
+        model = models.CensusProfile
+
+    id = factory.Sequence(lambda n: '16000US%07d' % n)
+    location = factory.Sequence(lambda n: 'Location %d' % n)
+    geography = 'place'
+    state = 'AA'
+    source = 'ACS 5-Year Data (2010-2014)'
+    white = factory.fuzzy.FuzzyInteger(1, 100)
+    black = factory.fuzzy.FuzzyInteger(1, 100)
+    native_american = factory.fuzzy.FuzzyInteger(1, 100)
+    asian = factory.fuzzy.FuzzyInteger(1, 100)
+    native_hawaiian = factory.fuzzy.FuzzyInteger(1, 100)
+    other = factory.fuzzy.FuzzyInteger(1, 100)
+    two_or_more_races = factory.fuzzy.FuzzyInteger(1, 100)
+
+    total = factory.LazyAttribute(
+        lambda o: (
+            o.white + o.black + o.native_american +
+            o.asian + o.native_hawaiian + o.other +
+            o.two_or_more_races
+        )
+    )
+
+    hispanic = factory.LazyAttribute(
+        lambda o: math.floor(0.2 * o.total)
+    )
+
+    non_hispanic = factory.LazyAttribute(
+        lambda o: o.total - o.hispanic
+    )

--- a/tsdata/tests/test_census_profile.py
+++ b/tsdata/tests/test_census_profile.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from tsdata.tests.factories import CensusProfileFactory
+
+
+class ModelTests(TestCase):
+
+    def test_census_dict(self):
+
+        def sum_these_keys(d, keys):
+            return sum([
+                d[key] for key in keys
+            ])
+
+        cp = CensusProfileFactory()
+        census_dict = cp.get_census_dict()
+        race_keys = (
+            'white', 'black', 'native_american', 'asian', 'other'
+        )
+        ethnicity_keys = (
+            'hispanic', 'non_hispanic'
+        )
+        self.assertEqual(
+            set(census_dict.keys()),
+            set(race_keys + ethnicity_keys + ('total',))
+        )
+        self.assertEqual(
+            sum_these_keys(census_dict, race_keys),
+            sum_these_keys(census_dict, ('total',))
+        )
+        self.assertEqual(
+            sum_these_keys(census_dict, ethnicity_keys),
+            sum_these_keys(census_dict, ('total',))
+        )


### PR DESCRIPTION
Importing the data will populate agency tables with census GEOID values when present in `{MD,NC}_agencies.csv`.

The agency API will return a dictionary of census data with the same racial and ethnic breakdowns as in `census.temporary.json`.  Source of census data is not provided.  (The front-end code currently
ignores the year from `census.temporary.json` anyway.)

`NC_agencies.csv` covers all of the small number of locales in `census.temporary.json` other than "Charlotte-Mecklenburg Police Department".

Future (after this pull request):
- front-end changes to use the new API (and remove  `census.temporary.json`)
- what census source to show on front-end for census data?