### PR TITLE
ODPM-103: making dashboard tables responsive

### DIFF
--- a/traffic_stops/static/js/app/base/TableBase.js
+++ b/traffic_stops/static/js/app/base/TableBase.js
@@ -26,7 +26,8 @@ export default Backbone.Model.extend({
   draw_table: function(){
     var div = $(this.get("selector")),
         matrix = this.get_tabular_data(),
-        tbl = $('<table>').attr("class", "table table-striped table-condensed dash-tables"),
+        resp = $('<div class="table-responsive">'),
+        tbl = $('<table class="table">').attr("class", "table table-striped table-condensed dash-tables"),
         tbody = $('<tbody>');
 
     matrix.forEach(function(row, i){
@@ -37,7 +38,8 @@ export default Backbone.Model.extend({
       });
       tbody.append(tr);
     });
+    resp.append(tbl);
     tbl.append(tbody);
-    div.prepend(tbl);
+    div.prepend(resp);
   }
 });

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -582,10 +582,6 @@ h4.graph-label {
 /* Dashboard data tables
 ========================================= */
 
-.dash-tables {
-  table-layout: fixed;
-}
-
 .raceSelector {
   border: 2px solid rgb(108, 108, 108);
   padding: 6px;


### PR DESCRIPTION
Bootstrap's [responsive tables](http://getbootstrap.com/css/#tables-responsive) are a decent solution to our word-wrapping woes. With these, too-wide tables will simply be horizontally scrollable. No more word-wrapping.