### PR TITLE
ODPM-101: improved graph scaling

### DIFF
--- a/traffic_stops/static/js/app/base/VisualBase.js
+++ b/traffic_stops/static/js/app/base/VisualBase.js
@@ -19,7 +19,7 @@ export default Backbone.Model.extend({
   onResize: function () {
     d3.select(this.svg[0])
       .style({ width:  `${this.div.width()}px`
-             , height: `${this.div.width()}px` });
+             , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` });
   },
   loader_show: function(){
     this.loader_div = $('<div>')

--- a/traffic_stops/static/js/app/base/VisualBase.js
+++ b/traffic_stops/static/js/app/base/VisualBase.js
@@ -9,10 +9,17 @@ export default Backbone.Model.extend({
     this.setDOM();
     this.loader_show();
     this.setDefaultChart();
+
+    $(window).on('resize', this.onResize.bind(this))
   },
   setDOM: function(){
     this.svg = $(this.get("selector"));
     this.div = $(this.svg).parent();
+  },
+  onResize: function () {
+    d3.select(this.svg[0])
+      .style({ width:  `${this.div.width()}px`
+             , height: `${this.div.width()}px` });
   },
   loader_show: function(){
     this.loader_div = $('<div>')

--- a/traffic_stops/static/js/app/common/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/common/ContrabandHitRate.js
@@ -127,7 +127,7 @@ export const ContrabandHitRateBarBase = VisualBase.extend({
             .attr('width', "100%")
             .attr('height', "100%")
             .style({ width:  `${this.div.width()}px`
-                   , height: `${this.get('height')}px` })
+                   , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
             .attr('preserveAspectRatio', "xMinYMin")
             .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
             .call(this.chart);

--- a/traffic_stops/static/js/app/common/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/common/ContrabandHitRate.js
@@ -115,12 +115,18 @@ export const ContrabandHitRateBarBase = VisualBase.extend({
     this.selector = selector;
   },
 
+  onResize: function () {
+    d3.select(this.svg[0])
+      .style({ width:  `${this.div.width()}px`
+             , height: `${this.get('height')}px` });
+  },
+
   drawChart: function(){
     d3.select(this.svg[0])
             .datum(this.dataset)
             .attr('width', "100%")
             .attr('height', "100%")
-            .style({ width:  `${this.get('width')}px`
+            .style({ width:  `${this.div.width()}px`
                    , height: `${this.get('height')}px` })
             .attr('preserveAspectRatio', "xMinYMin")
             .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -128,19 +128,13 @@ export const LikelihoodOfSearchBase = VisualBase.extend({
     this.selector = selector;
   },
 
-  onResize: function () {
-    d3.select(this.svg[0])
-      .style({ width:  `${this.div.width()}px`
-             , height: `${this.get('height')}px` });
-  },
-
   drawChart: function () {
     d3.select(this.svg[0])
       .datum(this.dataset)
       .attr('width', "100%")
       .attr('height', "100%")
       .style({ width:  `${this.div.width()}px`
-             , height: `${this.get('height')}px` })
+             , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
       .attr('preserveAspectRatio', "xMinYMin")
       .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
       .call(this.chart);

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -128,12 +128,18 @@ export const LikelihoodOfSearchBase = VisualBase.extend({
     this.selector = selector;
   },
 
+  onResize: function () {
+    d3.select(this.svg[0])
+      .style({ width:  `${this.div.width()}px`
+             , height: `${this.get('height')}px` });
+  },
+
   drawChart: function () {
     d3.select(this.svg[0])
       .datum(this.dataset)
       .attr('width', "100%")
       .attr('height', "100%")
-      .style({ width:  `${this.get('width')}px`
+      .style({ width:  `${this.div.width()}px`
              , height: `${this.get('height')}px` })
       .attr('preserveAspectRatio', "xMinYMin")
       .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)

--- a/traffic_stops/static/js/app/common/Stops.js
+++ b/traffic_stops/static/js/app/common/Stops.js
@@ -156,8 +156,8 @@ export const StopRatioDonutBase = VisualBase.extend({
           .datum(data)
           .attr('width', "100%")
           .attr('height', "100%")
-          .style({ width:  `${this.get('width')}px`
-                 , height: `${this.get('height')}px` })
+          .style({ width:  `${this.div.width()}px`
+                 , height: `${this.div.width()}px` })
         .transition().duration(1200)
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
@@ -211,6 +211,12 @@ export const StopRatioTimeSeriesBase = VisualBase.extend({
 
   drawStartup: function () {},
 
+  onResize: function () {
+    d3.select(this.svg[0])
+      .style({ width:  `${this.div.width()}px`
+             , height: `${this.get('height')}px` });
+  },
+
   drawChart: function(){
     var data = this._formatData();
 
@@ -219,7 +225,7 @@ export const StopRatioTimeSeriesBase = VisualBase.extend({
           .datum(data)
           .attr('width', "100%")
           .attr('height', "100%")
-          .style({ width:  `${this.get('width')}px`
+          .style({ width:  `${this.div.width()}px`
                  , height: `${this.get('height')}px` })
           .attr('preserveAspectRatio', "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)

--- a/traffic_stops/static/js/app/common/Stops.js
+++ b/traffic_stops/static/js/app/common/Stops.js
@@ -157,7 +157,7 @@ export const StopRatioDonutBase = VisualBase.extend({
           .attr('width', "100%")
           .attr('height', "100%")
           .style({ width:  `${this.div.width()}px`
-                 , height: `${this.div.width()}px` })
+                 , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
         .transition().duration(1200)
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
@@ -211,12 +211,6 @@ export const StopRatioTimeSeriesBase = VisualBase.extend({
 
   drawStartup: function () {},
 
-  onResize: function () {
-    d3.select(this.svg[0])
-      .style({ width:  `${this.div.width()}px`
-             , height: `${this.get('height')}px` });
-  },
-
   drawChart: function(){
     var data = this._formatData();
 
@@ -226,7 +220,7 @@ export const StopRatioTimeSeriesBase = VisualBase.extend({
           .attr('width', "100%")
           .attr('height', "100%")
           .style({ width:  `${this.div.width()}px`
-                 , height: `${this.get('height')}px` })
+                 , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
           .attr('preserveAspectRatio', "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -56,7 +56,7 @@ var CensusRatioDonut = VisualBase.extend({
       d3.select(this.svg[0])
           .datum(data)
           .style({ width:  `${this.div.width()}px`
-                 , height: `${this.div.width()}px` })
+                 , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
         .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")

--- a/traffic_stops/static/js/app/states/nc/Census.js
+++ b/traffic_stops/static/js/app/states/nc/Census.js
@@ -55,11 +55,11 @@ var CensusRatioDonut = VisualBase.extend({
     nv.addGraph(() => {
       d3.select(this.svg[0])
           .datum(data)
+          .style({ width:  `${this.div.width()}px`
+                 , height: `${this.div.width()}px` })
         .transition().duration(1200)
           .attr('width', "100%")
           .attr('height', "100%")
-          .style({ width:  `${this.get('width')}px`
-                 , height: `${this.get('height')}px` })
           .attr("preserveAspectRatio", "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);

--- a/traffic_stops/static/js/app/states/nc/UseOfForce.js
+++ b/traffic_stops/static/js/app/states/nc/UseOfForce.js
@@ -108,6 +108,8 @@ var UseOfForceBarChart = VisualBase.extend({
           .datum(data)
           .attr('width', "100%")
           .attr('height', "100%")
+          .style({ width:  `${this.div.width()}px`
+                 , height: `${ (this.get('height') / this.get('width')) * this.div.width() }px` })
           .attr('preserveAspectRatio', "xMinYMin")
           .attr('viewBox', `0 0 ${this.get('width')} ${this.get('height')}`)
           .call(this.chart);


### PR DESCRIPTION
The problem with IE before was fixed by assigning the `svg` elements fixed pixel widths and heights. This made them no longer *very small* on IE but broke their scaling behavior.

This adopts a more flexible solution. Pixel dimensions must still be used, as IE apparently demands this. But in order to preserve the flexible appearance of elements, we:

1. Set the dimensions on the basis of the parent container's dimensions & the view's built-in scaling factor
2. Watch for window resize events and re-set the dimensions of graphs

The size-updating callback defined on `VisualBase` includes a default implementation that is overridden on some inheritors of that class.