### PR TITLE
stop excluding md from flake 8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=100
-exclude=migrations,docs,fabfile.py,md/
+exclude=migrations,docs,fabfile.py


### PR DESCRIPTION
MD had been excluded from flake 8. I'm not sure why, but then builds failed if they had flake 8 errors. @copelco do you have insight on why we were ignoring flake 8 for MD and if there are any negative consequences to no longer ignoring it?

This pr removes md from the flake8 exclusions.