### PR TITLE
Add Find a Stop form to tab on state homepages

### DIFF
--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -1,6 +1,6 @@
 {% extends 'state.html' %}
 
-{% load staticfiles %}
+{% load staticfiles bootstrap3 %}
 
 {% block state-name %}
   Maryland
@@ -52,6 +52,31 @@
       </div>
   </form>
 {% endblock search-form %}
+
+{% block find-a-stop %}
+  <p class="agency-intro">
+    Search for Maryland stops using the form fields below. Use
+    <a href='{% url 'md:stops-search' %}'>Advanced Search</a>
+    for additional filtering criteria.
+  </p>
+  <form action="{% url 'md:stops-search' %}" method="get" class="form row">
+    <div class="col-md-12">
+      {% bootstrap_field find_a_stop_form.agency %}
+      <div class="row">
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.start_date %}</div>
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.end_date %}</div>
+      </div>
+      <div class="row">
+          <div class="col-md-3">{% bootstrap_field find_a_stop_form.age %}</div>
+          <div class="col-md-3">{% bootstrap_field find_a_stop_form.gender %}</div>
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.ethnicity %}</div>
+      </div>
+      {% buttons %}
+          <button type="submit" class="btn btn-primary pull-right">Submit</button>
+      {% endbuttons %}
+    </div>
+  </form>
+{% endblock find-a-stop %}
 
 {% block agencies-table %}
   <table class='table table-condensed table-hover'>

--- a/md/tests/test_views.py
+++ b/md/tests/test_views.py
@@ -91,3 +91,12 @@ class ViewTests(TestCase):
         response = views.search(request)
         text = 'Stops (0 total)'
         self.assertContains(response, text, status_code=200)
+
+    def test_homepage_find_a_stop(self):
+        "Test Find a Stop form is present on MD homepage"
+        response = self.client.get(reverse('md:home'))
+        # make sure form is in context
+        self.assertTrue('find_a_stop_form' in response.context)
+        form = response.context['find_a_stop_form']
+        # make sure required agency field label is present
+        self.assertContains(response, form['agency'].label)

--- a/md/views.py
+++ b/md/views.py
@@ -10,6 +10,11 @@ class Home(base_views.Home):
     template_name = 'md.html'
     success_url = 'md:agency-detail'
 
+    def get_context_data(self, **kwargs):
+        context = super(Home, self).get_context_data(**kwargs)
+        context['find_a_stop_form'] = forms.SearchForm()
+        return context
+
 
 def search(request):
     query = None

--- a/nc/templates/nc.html
+++ b/nc/templates/nc.html
@@ -1,6 +1,6 @@
 {% extends 'state.html' %}
 
-{% load staticfiles %}
+{% load staticfiles bootstrap3 %}
 
 {% block state-name %}
   North Carolina
@@ -52,6 +52,34 @@
       </div>
   </form>
 {% endblock search-form %}
+
+{% block find-a-stop %}
+  <p class="agency-intro">
+    Search for North Carolina stops using the form fields below. Use
+    <a href='{% url 'nc:stops-search' %}'>Advanced Search</a>
+    for additional filtering criteria.
+  </p>
+  <form action="{% url 'nc:stops-search' %}" method="get" class="form row">
+    <div class="col-md-12">
+      {% bootstrap_field find_a_stop_form.agency %}
+      <div class="row">
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.start_date %}</div>
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.end_date %}</div>
+      </div>
+      <div class="row">
+          <div class="col-md-3">{% bootstrap_field find_a_stop_form.age %}</div>
+          <div class="col-md-3">{% bootstrap_field find_a_stop_form.gender %}</div>
+      </div>
+      <div class="row">
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.race %}</div>
+          <div class="col-md-6">{% bootstrap_field find_a_stop_form.ethnicity %}</div>
+      </div>
+      {% buttons %}
+          <button type="submit" class="btn btn-primary pull-right">Submit</button>
+      {% endbuttons %}
+    </div>
+  </form>
+{% endblock find-a-stop %}
 
 {% block agencies-table %}
   <table class='table table-condensed table-hover'>

--- a/nc/tests/test_views.py
+++ b/nc/tests/test_views.py
@@ -63,3 +63,12 @@ class ViewTests(TestCase):
             self.assertEqual(2, len(chunks[0]))
             self.assertEqual(2, len(chunks[1]))
             self.assertEqual(1, len(chunks[2]))
+
+    def test_homepage_find_a_stop(self):
+        "Test Find a Stop form is present on NC homepage"
+        response = self.client.get(reverse('md:home'))
+        # make sure form is in context
+        self.assertTrue('find_a_stop_form' in response.context)
+        form = response.context['find_a_stop_form']
+        # make sure required agency field label is present
+        self.assertContains(response, form['agency'].label)

--- a/nc/views.py
+++ b/nc/views.py
@@ -9,6 +9,11 @@ class Home(base_views.Home):
     template_name = 'nc.html'
     success_url = 'nc:agency-detail'
 
+    def get_context_data(self, **kwargs):
+        context = super(Home, self).get_context_data(**kwargs)
+        context['find_a_stop_form'] = forms.SearchForm()
+        return context
+
 
 def search(request):
     query = None

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -389,6 +389,9 @@ body#state {
   #elevator {
     font-size: 110%;
   }
+  .tab-pane p:first-of-type {
+    margin-top: 12px;
+  }
 }
 
 /* Find a Traffic Stop page

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -90,7 +90,8 @@
             {% endblock agencies-table %}
           </div>
           <div class="tab-pane" id="find-a-stop" role="tabpanel">
-
+            {% block find-a-stop %}
+            {% endblock find-a-stop %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Branched off Neil/Rebecca's branch. Let me know if it's easier for me to open this PR against dev.

I wasn't sure how to test this since it basically just GETs to another view entirely, but I wrote a basic test to verify the form exists. I also suggested an alternative form layout. Let me know what you all think.