### PR TITLE
Hotfix affix style

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -440,6 +440,30 @@ body#state {
   }
 }
 
+.agency-list-search {
+  background-color: #f8f8f8;
+
+  &.affix {
+    z-index: 1024;
+    width: 100%;
+    top: 50px;
+  }
+
+  .form-group {
+    margin: 20px 0;
+  }
+
+  .input-group {
+    * {
+      font-size: 18px;
+    }
+
+    input {
+      height: 39px;
+    }
+}
+}
+
 /* Find a Traffic Stop page
 ========================================= */
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -293,6 +293,10 @@ code {
         text-align: center;
       }
 
+      a.pull-right {
+        float: none !important;
+      }
+
       .title-container {
         margin-bottom: 20px;
         padding: 0 30px;


### PR DESCRIPTION
Because (I'm guessing) of some merge confusion, a critical piece of CSS got deleted; I did not notice this before I pushed because I didn't think that the Python text changes I made could affect CSS, but then again, other things were involved.

This restores the crucial piece of CSS and also adds a new rule to fix another style infelicity that I noticed while checking up on it.