### PR TITLE
Update prime cache sig to work for Django 1.8

### DIFF
--- a/nc/management/commands/prime_cache.py
+++ b/nc/management/commands/prime_cache.py
@@ -7,7 +7,7 @@ class Command(BaseCommand):
     """Prime cache on production server"""
 
     def add_arguments(self, parser):
-        parser.add_argument('url', default="http://0.0.0.0:8000/")
+        parser.add_argument('url', nargs='?', default="http://0.0.0.0:8000/")
 
     def handle(self, *args, **options):
         prime_cache.run(options['url'])

--- a/nc/management/commands/prime_cache.py
+++ b/nc/management/commands/prime_cache.py
@@ -6,8 +6,8 @@ from nc import prime_cache
 class Command(BaseCommand):
     """Prime cache on production server"""
 
+    def add_arguments(self, parser):
+        parser.add_argument('url', default="http://0.0.0.0:8000/")
+
     def handle(self, *args, **options):
-        url = None
-        if len(args) == 1:
-            url = args[0]
-        prime_cache.run(url)
+        prime_cache.run(options['url'])

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -13,7 +13,7 @@ ENDPOINTS = ('stops', 'stops_by_reason', 'use_of_force', 'searches', 'contraband
 
 def run(root, host='opendatapolicingnc.com'):
     headers = {'Host': host}
-    api = urllib.parse.urljoin(root, reverse('agency-api-list'))
+    api = urllib.parse.urljoin(root, reverse('nc:agency-api-list'))
     # get agencies
     r = requests.get(api, headers=headers)
     agencies = r.json()
@@ -26,7 +26,7 @@ def run(root, host='opendatapolicingnc.com'):
             req(uri, headers=headers)
         # prime first search page
         payload = {'agency': agency['name']}
-        search_uri = urllib.parse.urljoin(root, reverse('stops-search'))
+        search_uri = urllib.parse.urljoin(root, reverse('nc:stops-search'))
         req(search_uri, headers, payload)
 
 


### PR DESCRIPTION
This is usually run manually to prime NC's cache. Looks like the Django 1.8 upgrade broke it.