### PR TITLE
ODPM-128: Safari bugs

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -286,9 +286,10 @@ code {
 .vertical-align {
     .flex-layout();
     .align-items(center);
-    .flex-wrap(wrap);
+    .flex-wrap(nowrap);
 
     @media (max-width: 768px) {
+      .flex-wrap(wrap);
       > * {
         text-align: center;
       }

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -28,7 +28,7 @@
   <div class="container">
     <div class="row vertical-align">
       <div class="col-md-8 col-sm-6">
-        <h1>{% block state-name %}{% endblock state-name %}</h1>
+        <h1 class="title-container">{% block state-name %}{% endblock state-name %}</h1>
         <p>
           {% block state-subtitle %}
           {% endblock state-subtitle %}


### PR DESCRIPTION
For whatever reason, Safari was causing adjacent col-8 and col-4 elements in a row to wrap. Weird! This patch suppresses row wrapping on large screens for `vertical-align` elements (which happen to be the ones we're interested in).