### PR TITLE
ODPM-136: adding collapse toggle to search pages

### DIFF
--- a/md/templates/md/search.html
+++ b/md/templates/md/search.html
@@ -66,7 +66,7 @@
 {% bootstrap_messages %}
 <div class="row">
     <div class="col-md-12">
-        <form action="{% url 'md:stops-search' %}" method="get" class="form row">
+        <form action="{% url 'md:stops-search' %}" method="get" class="form row collapse {% if not stops %}in{% endif %}" id="search-form">
             <div class="col-md-6 fields-col left">
                 <h3>Basic Search</h3>
                 <div>
@@ -95,6 +95,11 @@
                 {% endbuttons %}
             </div>
         </form>
+
+        <div class="collapser" aria-expanded="{% if stops %}false{% else %}true{% endif %}" data-toggle="collapse" data-target="#search-form">
+            <span class="shown">Collapse</span> <span class="glyphicon glyphicon-chevron-up shown"></span>
+            <span class="collapsed">Show Search</span> <span class="glyphicon glyphicon-chevron-down collapsed"></span>
+        </div>
     </div>
     <div class="col-md-12">
         <h2>Stops ({{ pages.total_count|intcomma }} total)</h2>

--- a/nc/templates/nc/search.html
+++ b/nc/templates/nc/search.html
@@ -66,7 +66,7 @@
 {% bootstrap_messages %}
 <div class="row">
     <div class="col-md-12">
-        <form action="{% url 'nc:stops-search' %}" method="get" class="form row">
+        <form action="{% url 'nc:stops-search' %}" method="get" class="form row collapse {% if not people %}in{% endif %}" id="search-form">
             <div class="col-md-6 fields-col left">
                 <h3>Basic Search</h3>
                 <div>
@@ -99,6 +99,11 @@
                 {% endbuttons %}
             </div>
         </form>
+
+        <div class="collapser" aria-expanded="{% if people %}false{% else %}true{% endif %}" data-toggle="collapse" data-target="#search-form">
+            <span class="shown">Collapse</span> <span class="glyphicon glyphicon-chevron-up shown"></span>
+            <span class="collapsed">Show Search</span> <span class="glyphicon glyphicon-chevron-down collapsed"></span>
+        </div>
     </div>
     <div class="col-md-12">
         <h2>Stops ({{ pages.total_count|intcomma }} total)</h2>

--- a/traffic_stops/settings/base.py
+++ b/traffic_stops/settings/base.py
@@ -88,6 +88,7 @@ STATIC_URL = '/static/'
 # Additional locations of static files
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
+    os.path.join(PROJECT_ROOT, 'node_modules/bootstrap'),
 )
 
 # List of finder classes that know how to find static files in

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -82,6 +82,32 @@ table {
   word-wrap: break-word;
 }
 
+/***
+ * Element to show and hide collapsable content.
+ */
+.collapser {
+  cursor: pointer;
+  text-align: center;
+  font-size: 16px;
+
+  &[aria-expanded="false"] {
+    & > .collapsed {
+      display: inline-block;
+    }
+    & > .shown {
+      display: none;
+    }
+  }
+  &[aria-expanded="true"] {
+    & > .collapsed {
+      display: none;
+    }
+    & > .shown {
+      display: inline-block;
+    }
+  }
+}
+
 /* Sticky footer styles
 -------------------------------------------------- */
 


### PR DESCRIPTION
> The search form is so large that it doesn't look like there are any results after searching, depending on your screen size (see attached screenshot). Some thoughts, but I don't know what the right answer is:
> The collapse button in the mockup may help
> Maybe the search form should default to collapsed after a search?

This adds a collapse button and defaults the form to collapsed after a search.

Note that the change to `STATICFILES_DIRS` is required in order to let Bootstrap find its fonts, which are used for the upwards and downward chevrons in the collapser element