### PR TITLE
ODPM-128: Safari flex-wrap bug, attempt #2

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -329,6 +329,11 @@ code {
     .align-items(center);
     .flex-wrap(wrap);
 
+    .col-md-4 {
+      // addressing a bizarre Safari bug
+      .flex-basis(33.2329%);
+    }
+
     @media (max-width: 768px) {
       > * {
         text-align: center;

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -303,10 +303,12 @@ code {
   }
 
   @media (max-width: @screen-sm-min) {
+    padding-top: 60px;
     padding-bottom: 30px;
 
     &.agency-detail {
-      padding-top: 60px;
+      padding-top: 80px;
+      padding-bottom: 50px;
     }
 
     p {
@@ -325,14 +327,14 @@ code {
 
 // http://stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3
 .vertical-align {
-    .flex-layout();
-    .align-items(center);
-    .flex-wrap(wrap);
-
-    .col-md-4 {
-      // addressing a bizarre Safari bug
-      .flex-basis(33.2329%);
-    }
+  #state & .title-container {
+    /***
+     * In practice, the only place where nontrivial vertical alignment
+     * takes place is on the state homepage. Hence we can use a page-specific
+     * special margin rule and get the same effect.
+     */
+    margin-top: 20px;
+  }
 
     @media (max-width: 768px) {
       > * {
@@ -344,6 +346,7 @@ code {
       }
 
       .title-container {
+        margin-top: 0;
         margin-bottom: 20px;
         padding: 0 30px;
         border-bottom: 1px solid white;


### PR DESCRIPTION
For whatever reason, Safari is choosing to (flex-)wrap adjacent elements with width 66.66666667% and 33.33333333%. One might assume that these do not sum to > 100%, but life is funny that way.

This addresses the issue by simply re-implementing the `.vertical-align` class so as to not use flexbox but instead use explicit padding. This is less elegant and correct than flexbox, but since we have relatively few pages to worry about, we can definitely enumerate the spacing for each without it being a big deal.