### PR TITLE
ODPM-141: adding .responsive-table wrapper to search result tables

### DIFF
--- a/md/templates/md/search.html
+++ b/md/templates/md/search.html
@@ -103,26 +103,28 @@
     </div>
     <div class="col-md-12">
         <h2>Stops ({{ pages.total_count|intcomma }} total)</h2>
-        <table class="table">
-            <tr>
-                <th>Date</th>
-                <th>Gender</th>
-                <th>Ethnicity</th>
-                <th>Age</th>
-                <th>Stop Location</th>
-                <th>Officer ID</th>
-            </tr>
-            {% for stop in stops %}
-            <tr title='{{ person.stop.stop_id }}'>
-                <td>{{ stop.date|date:"n/j/Y P" }}</td>
-                <td>{{ stop.get_gender_display }}</td>
-                <td>{{ stop.get_ethnicity_display }}</td>
-                <td>{{ stop.age }}</td>
-                <td>{{ stop.stop_location }}</td>
-                <td><a href='{% url "md:agency-detail" stop.agency_id %}?officer_id={{ stop.officer_id|urlencode }}'>{{ stop.officer_id }}</a></td>
-            </tr>
-            {% endfor %}
-        </table>
+        <div class="table-responsive">
+            <table class="table">
+                <tr>
+                    <th>Date</th>
+                    <th>Gender</th>
+                    <th>Ethnicity</th>
+                    <th>Age</th>
+                    <th>Stop Location</th>
+                    <th>Officer ID</th>
+                </tr>
+                {% for stop in stops %}
+                <tr title='{{ person.stop.stop_id }}'>
+                    <td>{{ stop.date|date:"n/j/Y P" }}</td>
+                    <td>{{ stop.get_gender_display }}</td>
+                    <td>{{ stop.get_ethnicity_display }}</td>
+                    <td>{{ stop.age }}</td>
+                    <td>{{ stop.stop_location }}</td>
+                    <td><a href='{% url "md:agency-detail" stop.agency_id %}?officer_id={{ stop.officer_id|urlencode }}'>{{ stop.officer_id }}</a></td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
         {% show_pages %}
     </div>
 </div>

--- a/nc/templates/nc/search.html
+++ b/nc/templates/nc/search.html
@@ -107,28 +107,30 @@
     </div>
     <div class="col-md-12">
         <h2>Stops ({{ pages.total_count|intcomma }} total)</h2>
-        <table class="table">
-            <tr>
-                <th>Date</th>
-                <th>Gender</th>
-                <th>Race</th>
-                <th>Ethnicity</th>
-                <th>Age</th>
-                <th>Agency</th>
-                <th>Officer ID</th>
-            </tr>
-            {% for person in people %}
-            <tr title='{{ person.stop.stop_id }}'>
-                <td>{{ person.stop.date|date:"n/j/Y P" }}</td>
-                <td>{{ person.get_gender_display }}</td>
-                <td>{{ person.get_race_display }}</td>
-                <td>{{ person.get_ethnicity_display }}</td>
-                <td>{{ person.age }}</td>
-                <td><a href='{% url "nc:agency-detail" person.stop.agency_id %}'>{{ person.stop.agency_description|truncatewords:3 }}</a></td>
-                <td><a href='{% url "nc:agency-detail" person.stop.agency_id %}?officer_id={{ person.stop.officer_id|urlencode }}'>{{ person.stop.officer_id }}</a></td>
-            </tr>
-            {% endfor %}
-        </table>
+        <div class="table-responsive">
+            <table class="table">
+                <tr>
+                    <th>Date</th>
+                    <th>Gender</th>
+                    <th>Race</th>
+                    <th>Ethnicity</th>
+                    <th>Age</th>
+                    <th>Agency</th>
+                    <th>Officer ID</th>
+                </tr>
+                {% for person in people %}
+                <tr title='{{ person.stop.stop_id }}'>
+                    <td>{{ person.stop.date|date:"n/j/Y P" }}</td>
+                    <td>{{ person.get_gender_display }}</td>
+                    <td>{{ person.get_race_display }}</td>
+                    <td>{{ person.get_ethnicity_display }}</td>
+                    <td>{{ person.age }}</td>
+                    <td><a href='{% url "nc:agency-detail" person.stop.agency_id %}'>{{ person.stop.agency_description|truncatewords:3 }}</a></td>
+                    <td><a href='{% url "nc:agency-detail" person.stop.agency_id %}?officer_id={{ person.stop.officer_id|urlencode }}'>{{ person.stop.officer_id }}</a></td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
         {% show_pages %}
     </div>
 </div>


### PR DESCRIPTION
Fixes the problem of not being able to get at the Officer ID column on small screen widths.

To verify, view some search results ([example](http://localhost:8000/md/search/?agency=Montgomery+County+Sheriff%27s+Office&start_date=&end_date=&age=&ethnicity=&gender=&officer=)); turn on mobile emulation or narrow the window to < 400px; verify that you can scroll the results table to the right to see the Officer ID column.