### PR TITLE
ODPM-130: New fix for anchor link scrolling

### DIFF
--- a/md/templates/md/agency_detail.html
+++ b/md/templates/md/agency_detail.html
@@ -8,7 +8,7 @@
   <!-- census data -->
   <div id="census_row" class="row optional">
     <div class="col-md-12 headline">
-      <h2 id='demographics'>ACS Census Data (2010 - 2014)</h2>
+      <h2>ACS Census Data (2010 - 2014)<a class="anchor-offset" id="demographics"></a></h2>
     </div>
 
 
@@ -48,7 +48,7 @@
 {% block stop-display %}
   <div class="row">
     <div class="col-md-12 headline">
-      <h2 id="stop-percentage">Traffic Stops</h2>
+      <h2>Traffic Stops<a class="anchor-offset" id="stop-percentage"></a></h2>
     </div>
   </div>
 
@@ -113,7 +113,7 @@
 {% block search-rate-display %}
   <div class="row">
     <div class="col-md-12 headline">
-      <h2 id="search-percentage-dept">{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Rate</h2>
+      <h2>{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Rate<a class="anchor-offset" id="search-percentage-dept"></a></h2>
     </div>
   </div>
 

--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -18,7 +18,7 @@
   <!-- census data -->
   <div id="census_row" class="row optional">
     <div class="col-md-12 headline">
-      <h2 id='demographics'>ACS Census Data (2010 - 2014)</h2>
+      <h2>ACS Census Data (2010 - 2014)<a class="anchor-offset" id="demographics"></a></h2>
     </div>
 
 
@@ -54,7 +54,7 @@
 {% block stop-display %}
   <div class="row">
     <div class="col-md-12 headline">
-      <h2 id="stop-percentage">Traffic Stops</h2>
+      <h2>Traffic Stops <a class="anchor-offset" id="stop-percentage"></a></h2>
     </div>
   </div>
 
@@ -119,7 +119,7 @@
 {% block search-rate-display %}
   <div class="row">
     <div class="col-md-12 headline">
-      <h2 id="search-percentage-dept">{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Rate</h2>
+      <h2>{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Rate<a class="anchor-offset" id="search-percentage-dept"></a></h2>
     </div>
   </div>
 

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -589,9 +589,22 @@ h2.officer {
   margin-top: 1rem;
   border-bottom: 1px solid @gray;
 
+  .anchor-offset {
+    position: absolute;
+    top: -50px;
+  }
+
+  @media (min-width: 768px) {
+    .anchor-offset {
+      position: absolute;
+      top: -138px;
+    }
+  }
+
   > h2 {
     margin-bottom: 20px;
     font-size: 40px;
+    position: relative;
   }
 }
 
@@ -602,15 +615,6 @@ h2.officer {
 .optional,
 .nav li.optional {
   display: none;
-}
-
-/***
- * To accommodate the extra padding added to anchor elements without breaking
- * the accessibility of controls (see `fixAnchorElements in base
- * agency_detail.html), we hide overflow in rows.
- */
-.row {
-  overflow: hidden;
 }
 
 /***

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -597,7 +597,7 @@ h2.officer {
   @media (min-width: 768px) {
     .anchor-offset {
       position: absolute;
-      top: -138px;
+      top: -158px;
     }
   }
 

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -76,30 +76,11 @@
 
       var $body = $('body');
       var $window = $(window);
-      var $graphsNav = $('#graphs-nav');
-      var BREAKPOINT = 770;
 
       $body.scrollspy({ target: '#graphs-nav', offset: 50 });
       $window.on('load', function () {
         $body.scrollspy('refresh');
       });
-
-      (function fixAnchorElements () {
-        var $anchors = $('.headline > h2');
-        var offset =
-          $('.navbar').height()
-          + ($window.width() > BREAKPOINT ? $graphsNav.outerHeight() : 0)
-          + 12;
-
-        $anchors
-          .each(function () {
-            $(this).css({
-              'padding-top': offset + 'px'
-            , 'margin-top': (-offset) + 'px'
-            })
-          })
-        ;
-      })();
     });
   </script>
 {% endblock extra-js %}


### PR DESCRIPTION
IE has some weird behavior related to overflow hiding and scrolling. Well, maybe it's not weird: IE refuses to scroll to the top of an element when that top is not visible. It will only scroll to the highest visible point. All other browsers behave differently.

This new implementation of the scrolling fix dispenses with the padding trickery that made overflow-hiding necessary in the first place. Instead it uses an arealess floating `a` element positioned above the target and containing its ID. This has the further advantage of removing the need for extra JS.

To verify:

- Fire up IE.
- Go to an agency detail page.
- Click one of the links in the header (e.g. "Departmental Search Rate"). Verify that it scrolls in such a way that the headline text is visible.
- For good measure, do the same with a mobile-width window.