### PR TITLE
change form text to Officer ID

### DIFF
--- a/md/forms.py
+++ b/md/forms.py
@@ -21,6 +21,7 @@ class SearchForm(forms.Form):
         widget=AutoCompleteWidget(AgencyLookup),
         help_text="ex: Montgomery County Police Department")
     officer = forms.CharField(
+        label='Officer ID',
         required=False,
         help_text="ex: 227")
     start_date = forms.DateField(

--- a/nc/forms.py
+++ b/nc/forms.py
@@ -20,6 +20,7 @@ class SearchForm(forms.Form):
         widget=AutoCompleteWidget(AgencyLookup),
         help_text="ex: Durham Police Department")
     officer = forms.CharField(
+        label="Officer ID",
         required=False,
         help_text="ex: 227")
     start_date = forms.DateField(

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -16,7 +16,7 @@
       </div>
       {% if officer_id %}
         <div class="col-sm-10 col-xs-12 title-container">
-          <h1>Data for Officer Alias: {{officer_id}}</h1>
+          <h1>Data for Officer ID: {{officer_id}}</h1>
           <h2 class="officer">{{ object }}</h2>
         </div>
       {% else %}


### PR DESCRIPTION
This responds to ticket ODPM-142 to make "Officer" read "Officer ID" on the search form and officer dashboard