### PR TITLE
ODPM-147: Adding lower limit to StopSearch time series graph

### DIFF
--- a/traffic_stops/static/js/app/common/StopSearch.js
+++ b/traffic_stops/static/js/app/common/StopSearch.js
@@ -78,6 +78,7 @@ export const StopSearchTimeSeriesBase = StopRatioTimeSeriesBase.extend({
                   .showLegend(true)
                   .showYAxis(true)
                   .showXAxis(true)
+                  .forceY(0)
                   .width(this.get("width"))
                   .height(this.get("height"));
 


### PR DESCRIPTION
We want the lower bound on the Y axis of the "Average Departmental Search Rate For Vehicle Stops" to be 0, not whatever the lowest displayed value happens to be. This fixes the lower limit.