### PR TITLE
Link to dev rtd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,9 @@ practices by North Carolina law enforcement agencies. This project is lead by
 the `Southern Coalition for Social Justice`_, a Durham-based civil rights
 organization.
 
-Please see the `documentation`_ for more information.
+Please see the `documentation`_ for more information. Note that the link is to
+the dev version of Read the Docs. When deploying to production, all links should
+be switched to the latest version of Read the Docs.
 
-.. _documentation: http://nc-traffic-stops.readthedocs.org/en/latest/
+.. _documentation: http://nc-traffic-stops.readthedocs.org/en/dev/
 .. _Southern Coalition for Social Justice: http://www.scsj.org/

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ practices by North Carolina law enforcement agencies. This project is lead by
 the `Southern Coalition for Social Justice`_, a Durham-based civil rights
 organization.
 
-Please see the `documentation`_ for more information. Note that the link is to
-the dev version of Read the Docs. When deploying to production, all links should
-be switched to the latest version of Read the Docs.
+Please see the `production documentation`_ and `development documentation`_
+for more information.
 
-.. _documentation: http://nc-traffic-stops.readthedocs.org/en/dev/
+.. _production documentation: http://nc-traffic-stops.readthedocs.org/en/latest/
+.. _development documentation: http://nc-traffic-stops.readthedocs.org/en/dev/
 .. _Southern Coalition for Social Justice: http://www.scsj.org/

--- a/traffic_stops/templates/about.html
+++ b/traffic_stops/templates/about.html
@@ -20,7 +20,7 @@
     </div>
     <div class="row-fluid">
         <h2>Developer documentation</h2>
-        #TODO on prod deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/
+        #TODO on deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/
         <p>
             Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.io/en/dev/">here</a>.
         </p>

--- a/traffic_stops/templates/about.html
+++ b/traffic_stops/templates/about.html
@@ -20,7 +20,7 @@
     </div>
     <div class="row-fluid">
         <h2>Developer documentation</h2>
-        #TODO on deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/
+{#        #TODO on deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/#}
         <p>
             Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.io/en/dev/">here</a>.
         </p>

--- a/traffic_stops/templates/about.html
+++ b/traffic_stops/templates/about.html
@@ -20,9 +20,8 @@
     </div>
     <div class="row-fluid">
         <h2>Developer documentation</h2>
-{#        #TODO on deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/#}
         <p>
-            Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.io/en/dev/">here</a>.
+            Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.org/">here</a>.
         </p>
     </div>
 </div>

--- a/traffic_stops/templates/about.html
+++ b/traffic_stops/templates/about.html
@@ -20,8 +20,9 @@
     </div>
     <div class="row-fluid">
         <h2>Developer documentation</h2>
+        #TODO on prod deploy switch this url to http://nc-traffic-stops.readthedocs.io/en/latest/
         <p>
-            Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.org/">here</a>.
+            Documentation, source-code, and the full dataset are available <a href="http://nc-traffic-stops.readthedocs.io/en/dev/">here</a>.
         </p>
     </div>
 </div>


### PR DESCRIPTION
Currently on staging, the link on the about page and in the README take the developer to the version of Read the Docs corresponding to the master branch. This pr provides two links in the readme, one to prod docs and one to dev docs, so that the developer can visit the docs matching the branch they are working on.
