### PR TITLE
remove investigation and failure to remain from stop purpose options …

### DIFF
--- a/traffic_stops/static/js/app/states/md/defaults.js
+++ b/traffic_stops/static/js/app/states/md/defaults.js
@@ -47,11 +47,11 @@ export default {
     'Safe Movement Violation': 1,
     'Vehicle Equipment Violation': 2,
     'Other Motor Vehicle Violation': 3,
-    'Stop Light/Sign Violation': 5,
-    'Speed Limit Violation': 6,
-    'Vehicle Regulatory Violation': 7,
-    'Seat Belt Violation': 8,
-    'Non-motor Vehicle Violations': 9,
-    'Other/Unknown': 11  // todo: use a list and indexOf instead of map
+    'Stop Light/Sign Violation': 4,
+    'Speed Limit Violation': 5,
+    'Vehicle Regulatory Violation': 6,
+    'Seat Belt Violation': 7,
+    'Non-motor Vehicle Violations': 8,
+    'Other/Unknown': 9  // todo: use a list and indexOf instead of map
   }),
 };

--- a/traffic_stops/static/js/app/states/md/defaults.js
+++ b/traffic_stops/static/js/app/states/md/defaults.js
@@ -47,13 +47,11 @@ export default {
     'Safe Movement Violation': 1,
     'Vehicle Equipment Violation': 2,
     'Other Motor Vehicle Violation': 3,
-    'Investigation': 4,
     'Stop Light/Sign Violation': 5,
     'Speed Limit Violation': 6,
     'Vehicle Regulatory Violation': 7,
     'Seat Belt Violation': 8,
     'Non-motor Vehicle Violations': 9,
-    'Failure to remain at scene of accident': 10,
     'Other/Unknown': 11  // todo: use a list and indexOf instead of map
   }),
 };


### PR DESCRIPTION
…for md graphs 

This addresses 149. We have no stops with the purpose "investigation" or "failure to remain" in MD, so those purposes shouldn't show up on the data table.

You will probably have to empty your browser cache to make these purposes go away.