### PR TITLE
Adding select input to filter Departmental Stop Count table

### DIFF
--- a/traffic_stops/static/js/app/base/TableBase.js
+++ b/traffic_stops/static/js/app/base/TableBase.js
@@ -33,6 +33,8 @@ export default Backbone.Model.extend({
         tbl = $('<table class="table">').attr("class", "table table-striped table-condensed dash-tables"),
         tbody = $('<tbody>');
 
+    div.find('table').remove();
+
     matrix.forEach(function(row, i){
       var tr = $('<tr>');
       row.forEach(function(d){

--- a/traffic_stops/static/js/test/base/test_AggregateDataHandlerBase.js
+++ b/traffic_stops/static/js/test/base/test_AggregateDataHandlerBase.js
@@ -1,0 +1,57 @@
+import { assert } from 'chai'
+import AggregateDataHandlerBase from '../../app/base/AggregateDataHandlerBase.js'
+import { __RewireAPI__ as ADHB } from '../../app/base/AggregateDataHandlerBase.js'
+import Backbone from 'backbone'
+
+describe('base', () => {
+  describe('DataHandlerBase', () => {
+    describe('get_data', () => {
+      let AggregateDataHandlerBase_ = AggregateDataHandlerBase.extend({
+        clean_data: () => true
+      })
+
+      it('returns a Promise', () => {
+        let adhb = new AggregateDataHandlerBase_({url: 'foo'})
+        let result = adhb.get_data()
+
+        assert.isTrue(result instanceof Promise)
+      })
+
+      it('aggregates data from all its handlers\' get_data promises', (done) => {
+        let [accept1, accept2] = ['accept1', 'accept2']
+
+        let AggregateDataHandlerBase_ = AggregateDataHandlerBase.extend({
+          /***
+           * Trivial clean_data method that will just pass along the
+           * input data so we can verify that this data is received and
+           * piped through the cleanup method.
+           */
+          clean_data: function () {
+            this.set('data', this.get('raw_data'))
+          }
+        })
+
+        let HandlerType = Backbone.Model.extend({
+          get_data: function () {
+            return new Promise((resolve, reject) => { resolve(this.get('accept')) })
+          }
+        })
+
+        let adhb = new AggregateDataHandlerBase_({
+          url: 'foo'
+        , handlers: [
+            new HandlerType({accept: accept1})
+          , new HandlerType({accept: accept2})
+          ]
+        })
+
+        let result = adhb.get_data()
+
+        result.then((data) => {
+          assert.includeMembers(data, [accept1, accept2])
+          done()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds a `select` input (similar to the one on the line chart) to let the user limit the number of displayed items on the data table for stop counts.

The `add_select` method is very similar to `drawStartup` on the line chart; the only serious differences are:

- it will only add the `select` element once
- it includes a bit of scroll-updating logic so that the user's scroll position doesn't jump around disorientingly

The only other change is making it so that the `draw_table` method erases previously drawn tables and redraws from scratch.