### PR TITLE
change driving population to local population in graph titles

### DIFF
--- a/md/templates/md/agency_detail.html
+++ b/md/templates/md/agency_detail.html
@@ -13,7 +13,7 @@
 
 
     <div class="col-md-12">
-      <h3>Driving Population (percentage by race)</h3>
+      <h3>Local Population (percentage by race)</h3>
 
       <p class="help-block">
         This graph reflects the racial composition of the jurisdiction at the

--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -23,7 +23,7 @@
 
 
     <div class="col-md-12">
-      <h3>Driving Population (percentage by race/ethnicity)</h3>
+      <h3>Local Population (percentage by race/ethnicity)</h3>
 
       <p class="help-block">
         This graph reflects the racial composition of the jurisdiction at the


### PR DESCRIPTION
We changed "driving population" to "local population" in graphs but not in titles.