### PR TITLE
Centering IL state graphic on IL state homepage

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -344,6 +344,12 @@ code {
     display: inline-block;
     padding: 10px 0;
   }
+
+  .state-header-graphic-col {
+    &.il {
+      text-align: center;
+    }
+  }
 }
 
 // http://stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -34,7 +34,7 @@
           {% endblock state-subtitle %}
         </p>
       </div>
-      <div class="col-md-4 col-sm-6 hidden-xs">
+      <div class="col-md-4 col-sm-6 hidden-xs state-header-graphic-col il">
         {% block state-header-graphic %}
         {% endblock state-header-graphic %}
       </div>


### PR DESCRIPTION
As @copelco pointed out, the IL state graphic looks awkward when left-aligned on the state homepage (`il/`).

This centers it in its container, which looks less weird.

It's an open question whether we want to do this to the other state homepages for consistency's sake.