### PR TITLE
ODPM-164: prepending chart select dropdowns

### DIFF
--- a/traffic_stops/static/js/app/common/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/common/ContrabandHitRate.js
@@ -108,9 +108,9 @@ export const ContrabandHitRateBarBase = VisualBase.extend({
       .on('change', getData)
       .trigger('change');
 
-    $('<div>')
+    $('<div class="selector-container">')
       .html(selector)
-      .appendTo(this.div);
+      .prependTo(this.div);
 
     this.selector = selector;
   },

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -121,9 +121,9 @@ export const LikelihoodOfSearchBase = VisualBase.extend({
       .on('change', getData)
       .trigger('change');
 
-    $('<div>')
+    $('<div class="selector-container">')
       .html(selector)
-      .appendTo(this.div);
+      .prependTo(this.div);
 
     this.selector = selector;
   },

--- a/traffic_stops/static/js/app/common/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/common/StopByReasonAndRace.js
@@ -51,7 +51,7 @@ export const SRRTimeSeriesBase = VisualBase.extend({
 
     $('<div class="selector-container">')
       .html($selector)
-      .appendTo(this.div);
+      .prependTo(this.div);
 
     update();
   },

--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -813,6 +813,7 @@ h4.graph-label {
 }
 
 .selector-container {
+  margin-top: 15px;
   width: 100%;
   > select {
     margin: 0 auto;


### PR DESCRIPTION
On charts that are preceded by help text that says something about using the chart's dropdown menu (e.g. the Departmental Stop Count chart), we'd like the dropdown to be closer to that text, i.e. above the chart and not after it.

This changes the `appendTo` call for dropdowns to `prependTo`, and it adjusts the appearance of those dropdowns' container elements to make them a bit more consistent and aesthetically acceptable.

These changes should be apparent on these charts:

- Departmental Stop Count
- Likelihood of Search by "Stop Cause"
- Contraband "Hit-Rate"