### PR TITLE
ODPM-168: Justifying homepage text

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -144,6 +144,10 @@ h1, h2, h3, h4, h5 {
   }
 }
 
+.justify {
+  text-align: justify;
+}
+
 /* Sticky footer styles
 -------------------------------------------------- */
 

--- a/traffic_stops/templates/home.html
+++ b/traffic_stops/templates/home.html
@@ -51,7 +51,7 @@
     <div class="row">
       <div class="col-sm-4">
         <h3>Locate an Officer's Career Stop and Search History</h3>
-        <p>
+        <p class="justify">
           Stopped by the police? Use our “Find a Stop” feature to locate your
             traffic stop. Click on the associated Officer ID number to display
             the enforcement history of the officer who stopped you. Maryland
@@ -62,7 +62,7 @@
       </div>
       <div class="col-sm-4">
         <h3>Review Departmental Enforcement Patterns</h3>
-        <p>
+        <p class="justify">
           Learn more about the enforcement patterns of individual police
             agencies. Metrics include stops, searches, search rates, contraband
             seizure rates, and the likelihood of search for individual stop
@@ -75,7 +75,7 @@
       </div>
       <div class="col-sm-4">
         <h3>Compare Enforcement Practices Among Officers and Jurisdictions</h3>
-        <p>
+        <p class="justify">
           Our platform allows users—including those in police management—to
             easily compare enforcement patterns among individual officers and
             agencies, evaluate the frequency and efficiency of searches, and
@@ -92,7 +92,7 @@
 <div class="about-footer">
   <div class="container">
     <div class="row">
-      <div class="col-sm-6">
+      <div class="col-sm-6 justify">
         <h3>About Open Data Policing</h3>
         <p>
           Open Data Policing is a first-of-its-kind platform that aims to make
@@ -115,7 +115,7 @@
         </p>
 
       </div>
-      <div class="col-sm-3">
+      <div class="col-sm-3 justify">
         <h3>Donate</h3>
         <p>
           Open Data Policing is a project of the Southern Coalition for Social


### PR DESCRIPTION
The text on the homepage should be justified (newspaper-style).

The headlines of the homepage's text blocks are not justified, as this results in some very weird word spacing.