### PR TITLE
ODPM-169 new prod machine swap space

### DIFF
--- a/conf/pillar/production.sls
+++ b/conf/pillar/production.sls
@@ -8,7 +8,7 @@ letsencrypt: true
 
 repo:
   url: https://github.com/OpenDataPolicingNC/Traffic-Stops.git
-  branch: dev
+  branch: ODPM-169-new-prod-machine-swap-space
 
 postgresql_config: # from pgtune
   work_mem: 88MB

--- a/conf/pillar/production.sls
+++ b/conf/pillar/production.sls
@@ -8,7 +8,7 @@ letsencrypt: true
 
 repo:
   url: https://github.com/OpenDataPolicingNC/Traffic-Stops.git
-  branch: ODPM-169-new-prod-machine-swap-space
+  branch: dev
 
 postgresql_config: # from pgtune
   work_mem: 88MB

--- a/conf/pillar/project.sls
+++ b/conf/pillar/project.sls
@@ -9,9 +9,12 @@ postgres_extensions: [postgis]
 
 python_headers: [libxft-dev]
 
-margarita_version: 1.7.0
+margarita_version: 1.7.5
 
 admin_email: ccopeland@codeforamerica.org
+
+# Celery tasks run very infrequently and use a lot of memory.
+celery_worker_arguments: "--loglevel=INFO --maxtasksperchild 1"
 
 instances:
   - nc

--- a/conf/salt/project/web/gunicorn.conf
+++ b/conf/salt/project/web/gunicorn.conf
@@ -1,5 +1,5 @@
 [program:{{ pillar['project_name'] }}-server]
-command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=240
+command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=300
 user={{ pillar['project_name'] }}
 directory={{ directory }}
 autostart=true

--- a/conf/salt/project/web/gunicorn.conf
+++ b/conf/salt/project/web/gunicorn.conf
@@ -1,5 +1,5 @@
 [program:{{ pillar['project_name'] }}-server]
-command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=120
+command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=180
 user={{ pillar['project_name'] }}
 directory={{ directory }}
 autostart=true

--- a/conf/salt/project/web/gunicorn.conf
+++ b/conf/salt/project/web/gunicorn.conf
@@ -1,5 +1,5 @@
 [program:{{ pillar['project_name'] }}-server]
-command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=180
+command={{ directory }}/dotenv.sh {% if use_newrelic %}{{ virtualenv_root }}/bin/newrelic-admin run-program {% endif %}{{ virtualenv_root }}/bin/gunicorn {{ pillar['project_name'] }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ grains['num_cpus'] * 2 + 1 }} --timeout=240
 user={{ pillar['project_name'] }}
 directory={{ directory }}
 autostart=true

--- a/docs/data-import.rst
+++ b/docs/data-import.rst
@@ -105,6 +105,20 @@ When finished, revoke SUPERUSER privileges:
 
     sudo -u postgres psql -c 'ALTER USER traffic_stops_staging WITH NOSUPERUSER;'
 
+When importing IL data on a server, paging space is required due to the memory
+requirements.  Currently the staging and production servers do not have a "swap"
+file or device permanently assigned, nor do they have a device on which paging
+space can be routinely used without incurring I/O charges.  Thus a swap file is
+activated prior to an import of IL data and then deactivated afterwards, as follows::
+
+    sudo fallocate -l 3G /swapfile
+    sudo chmod 600 /swapfile
+    sudo mkswap /swapfile
+    sudo swapon /swapfile
+    <<perform the IL data import using the appropriate mechanism>>
+    sudo swapoff /swapfile
+    sudo rm /swapfile
+
 After importing new state data into the database used by a running server,
 cached queries will continue to be used until they expire.  To flush the
 cache, connect to ``memcached`` using ``telnet`` or some other suitable

--- a/docs/data-import.rst
+++ b/docs/data-import.rst
@@ -130,6 +130,9 @@ requests on the server box which bypass nginx::
     sudo su - traffic_stops
     /var/www/traffic_stops/manage.sh  prime_cache --host opendatapolicing.com http://127.0.0.1:8000/
 
+(Use the appropriate ``--host`` argument based on the canonical name for the
+server.)
+
 NC queries should be primed in this manner because some of them take longer than
 the nginx timeout to perform the first time, resulting in users encountering
 error pages instead of agency results.

--- a/docs/data-import.rst
+++ b/docs/data-import.rst
@@ -110,6 +110,16 @@ cached queries will continue to be used until they expire.  To flush the
 cache, connect to ``memcached`` using ``telnet`` or some other suitable
 client and send the ``flush_all`` command.
 
+After importing NC data on staging or production, prime the query cache via
+requests on the server box which bypass nginx::
+
+    sudo su - traffic_stops
+    /var/www/traffic_stops/manage.sh  prime_cache --host opendatapolicing.com http://127.0.0.1:8000/
+
+NC queries should be primed in this manner because some of them take longer than
+the nginx timeout to perform the first time, resulting in users encountering
+error pages instead of agency results.
+
 Raw NC Data
 ___________
 

--- a/nc/management/commands/prime_cache.py
+++ b/nc/management/commands/prime_cache.py
@@ -8,7 +8,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('url', nargs='?', default="http://0.0.0.0:8000/")
-        parser.add_argument('--host', dest='host', default=None, help='Override "Host" request header')
+        parser.add_argument('--host', dest='host', default=None,
+                            help='Override "Host" request header')
 
     def handle(self, *args, **options):
         prime_cache.run(options['url'], host=options['host'])

--- a/nc/management/commands/prime_cache.py
+++ b/nc/management/commands/prime_cache.py
@@ -8,6 +8,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('url', nargs='?', default="http://0.0.0.0:8000/")
+        parser.add_argument('--host', dest='host', default=None, help='Override "Host" request header')
 
     def handle(self, *args, **options):
-        prime_cache.run(options['url'])
+        prime_cache.run(options['url'], host=options['host'])

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -11,8 +11,10 @@ logger = logging.getLogger(__name__)
 ENDPOINTS = ('stops', 'stops_by_reason', 'use_of_force', 'searches', 'contraband_hit_rate')
 
 
-def run(root, host='opendatapolicingnc.com'):
-    headers = {'Host': host}
+def run(root, host=None):
+    headers = dict()
+    if host is not None:
+        headers['Host'] = host
     api = urllib.parse.urljoin(root, reverse('nc:agency-api-list'))
     # get agencies
     r = requests.get(api, headers=headers)

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -34,9 +34,7 @@ def run(root, host=None):
 
 def req(uri, headers, payload=None):
     try:
-        # requests doc says there's no timeout by default, but the log showed
-        # timeouts every 120 seconds when accessing an expensive agency.
-        response = requests.get(uri, headers=headers, params=payload, timeout=300)
+        response = requests.get(uri, headers=headers, params=payload)
         if response.status_code != 200:
             logger.warning("Status not OK: {} ({})".format(
                            uri, response.status_code))

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -35,11 +35,12 @@ def run(root, host=None):
 def req(uri, headers, payload=None):
     try:
         response = requests.get(uri, headers=headers, params=payload)
+        if response.status_code != 200:
+            logger.warning("Status not OK: {} ({})".format(
+                           uri, response.status_code))
     except requests.ConnectionError as err:
-        logger.error(err)
-    if response.status_code != 200:
-        logger.warning("Status not OK: {} ({})".format(
-                       uri, response.status_code))
+        logger.error('Cannot load %s: %s', uri, err)
+        response = None
     return response
 
 

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -34,7 +34,9 @@ def run(root, host=None):
 
 def req(uri, headers, payload=None):
     try:
-        response = requests.get(uri, headers=headers, params=payload)
+        # requests doc says there's no timeout by default, but the log showed
+        # timeouts every 120 seconds when accessing an expensive agency.
+        response = requests.get(uri, headers=headers, params=payload, timeout=300)
         if response.status_code != 200:
             logger.warning("Status not OK: {} ({})".format(
                            uri, response.status_code))

--- a/traffic_stops/settings/deploy.py
+++ b/traffic_stops/settings/deploy.py
@@ -72,7 +72,7 @@ ALLOWED_HOSTS = [os.environ['DOMAIN']]
 
 # Uncomment if using celery worker configuration
 CELERY_SEND_TASK_ERROR_EMAILS = True
-BROKER_URL = 'amqp://traffic_stops_staging:%(BROKER_PASSWORD)s@%(BROKER_HOST)s/traffic_stops_staging' % os.environ  # noqa
+BROKER_URL = 'amqp://traffic_stops_%(ENVIRONMENT)s:%(BROKER_PASSWORD)s@%(BROKER_HOST)s/traffic_stops_%(ENVIRONMENT)s' % os.environ  # noqa
 
 LOGGING['handlers']['file']['filename'] = '/var/www/traffic_stops/log/traffic_stops.log'
 


### PR DESCRIPTION
**BEFORE MERGING**: Change the branch in `conf/pillar/production.sls` back to `dev`.

What does this pull request do w.r.t. swap?

1. Lessen virtual memory requirements slightly by configuring Celery worker processes to exit after one task, as they will hold on to some of the memory used to import, and the same process might not be used again for months.  (This changed the Margarita version from 1.7.0 to 1.7.5.  See https://github.com/caktus/margarita/blob/develop/CHANGES.rst .)
2. Document how to manually manage swap for the IL data import.

What unrelated things does this pull request do?

1. Fix prime_cache management command so that it doesn't hard-code the old production server domain name, and allow it to be used on staging or production (i.e., user specifies host header).
2. Document how to use prime_cache management command.
3. Increase Gunicorn timeout from 2 minutes to 5 minutes so that NC State Highway Patrol queries can finish.  (That needs to be done via the prime_cache management command so that the user doesn't see errors when the nginx timeout expires.)  See also ODPM-176.
4. Fix RabbitMQ settings so that RabbitMQ works on production, which in turn allows data to be imported.
