### PR TITLE
Add `hyphens: auto;` to `.justify` rules

### DIFF
--- a/traffic_stops/static/less/index.less
+++ b/traffic_stops/static/less/index.less
@@ -146,6 +146,9 @@ h1, h2, h3, h4, h5 {
 
 .justify {
   text-align: justify;
+  -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
 }
 
 /* Sticky footer styles


### PR DESCRIPTION
Justified text looks horrible, just horrible, without word hyphenation.

On Chrome, [there's nothing we can do about that](http://caniuse.com/#feat=css-hyphens) without some kind of JS preprocessing.

But that's no reason to not take advantage of the handy CSS3 `hyphens` property that works on IE, Safari, and Firefox. Those visitors can enjoy text that looks quite nice with the addition of this one simple rule.