### PR TITLE
Bypass New Relic middleware bug when priming cache

### DIFF
--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -28,6 +28,11 @@ def avoid_newrelic_bug():
     By disabling the browser_monitoring setting checked for just before the
     AttributeError, this New Relic gets out of the way before the problem.
 
+    In production, this normally runs in a Celery task that exits when the
+    import is finished due to the Celery "--maxtasksperchild 1" parameter.
+    Even if more tasks ran in the same process, they too won't be handling
+    browser requests so the setting change won't affect such tasks.
+
     This Mozilla project ticket has a copy of some correspondence with New Relic:
         https://bugzilla.mozilla.org/show_bug.cgi?id=1196043
     (I am unable to access the referenced New Relic ticket.)

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -13,6 +13,32 @@ ENDPOINTS = ('stops', 'stops_by_reason', 'use_of_force', 'searches', 'contraband
 DEFAULT_CUTOFF_SECS = 4
 
 
+def avoid_newrelic_bug():
+    """
+    New Relic middleware throws an exception when a web request is run in a
+    Celery task (without going through HTTP).
+
+    An AttributeError is thrown here:
+
+    https://github.com/edmorley/newrelic-python-agent/blob/v2.82.0.62/newrelic/
+    newrelic/hooks/framework_django.py#L93
+
+    AttributeError: 'BackgroundTask' object has no attribute 'rum_header_generated'
+
+    By disabling the browser_monitoring setting checked for just before the
+    AttributeError, this New Relic gets out of the way before the problem.
+
+    This Mozilla project ticket has a copy of some correspondence with New Relic:
+        https://bugzilla.mozilla.org/show_bug.cgi?id=1196043
+    (I am unable to access the referenced New Relic ticket.)
+    """
+    try:
+        from newrelic.hooks.framework_django import django_settings
+        django_settings.browser_monitoring.auto_instrument = False
+    except ImportError:
+        pass
+
+
 def run(cutoff_duration_secs=None):
     """
     Prime query cache for "big" NC agencies.
@@ -37,6 +63,9 @@ def run(cutoff_duration_secs=None):
     """
     if cutoff_duration_secs is None:
         cutoff_duration_secs = DEFAULT_CUTOFF_SECS
+
+    avoid_newrelic_bug()
+
     logger.info('NC prime_cache starting')
     agencies = [
         (a.id, a.name, a.num_stops)


### PR DESCRIPTION
The normal way the affected code is run on production is in a Celery task, resulting in an exception.  (See comments in the new code.)