### PR TITLE
Update Psycopg2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 Pillow==3.1.0
 Django==1.8.17
 six==1.10.0


### PR DESCRIPTION
Every travis build was failing due to the following error that is now occurring for psycopg2==2.6: 

    Error: could not determine PostgreSQL version from '10.1'

The issue is [discussed in the psycopg2 GitHub repo](https://github.com/psycopg/psycopg2/issues/594#issuecomment-346383873), and the recommendation is to update psycopg2 to a newer version. This pull request updates `psycopg2` to its newest version in order to fix the issue.