### PR TITLE
[TRH-2688] Improve Search Query Time

### DIFF
--- a/nc/data/copy.sql
+++ b/nc/data/copy.sql
@@ -96,6 +96,7 @@ CREATE INDEX nc_searchbasis_5fad4402 ON nc_searchbasis USING btree (search_id);
 CREATE INDEX nc_searchbasis_91455da7 ON nc_searchbasis USING btree (stop_id);
 CREATE INDEX nc_searchbasis_a8452ca7 ON nc_searchbasis USING btree (person_id);
 CREATE INDEX nc_stop_169fc544 ON nc_stop USING btree (agency_id);
+CREATE INDEX nc_stop_date_7d643c8a9c590bf7_uniq ON nc_stop USING btree (date);
 
 ANALYZE;
 COMMIT;

--- a/nc/migrations/0003_auto_20180115_1141.py
+++ b/nc/migrations/0003_auto_20180115_1141.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nc', '0002_agency_census_profile_id'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='stop',
+            name='date',
+            field=models.DateTimeField(db_index=True),
+        ),
+    ]

--- a/nc/models.py
+++ b/nc/models.py
@@ -60,7 +60,7 @@ class Stop(CachingMixin, models.Model):
     stop_id = models.PositiveIntegerField(primary_key=True)
     agency_description = models.CharField(max_length=100)
     agency = models.ForeignKey('Agency', null=True, related_name='stops')
-    date = models.DateTimeField()
+    date = models.DateTimeField(db_index=True)
     purpose = models.PositiveSmallIntegerField(choices=PURPOSE_CHOICES)
     action = models.PositiveSmallIntegerField(choices=ACTION_CHOICES)
     driver_arrest = models.BooleanField(default=False)


### PR DESCRIPTION
This change improves the query times for the stop search by adding an index to the date column and giving a hint to the query planner for computing the count. Locally I see the following improvement for the target search "/nc/search/?agency=NC+State+Highway+Patrol&start_date=02%2F01%2F2016&end_date=&age=&race=&ethnicity=&gender=&officer=" using debug toolbar.

Before change: 27055.24 ms (3 queries)
After change: 2296.81 ms (5 queries)

This is using date from 1/8/2018 which returns 1,007,953 results for the search.