### PR TITLE
[TRH-2624] Re-Add Ethnicity Data To NC Agency Page

### DIFF
--- a/traffic_stops/static/js/app/states/nc/ContrabandHitRate.js
+++ b/traffic_stops/static/js/app/states/nc/ContrabandHitRate.js
@@ -35,7 +35,7 @@ const ContrabandTable = C.ContrabandTableBase.extend({
     return Stops.pprint.values();
   },
 
-  types: [Stops.races]
+  types: [Stops.races, Stops.ethnicities]
 });
 
 export default {

--- a/traffic_stops/static/js/app/states/nc/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/states/nc/LikelihoodOfSearch.js
@@ -38,7 +38,7 @@ const LikelihoodOfSearch = C.LikelihoodOfSearchBase.extend({
 });
 
 const LikelihoodSearchTable = C.LikelihoodSearchTableBase.extend({
-  types: [Stops.races],
+  types: [Stops.races, Stops.ethnicities],
 
   Stops: Stops,
 

--- a/traffic_stops/static/js/app/states/nc/StopSearch.js
+++ b/traffic_stops/static/js/app/states/nc/StopSearch.js
@@ -6,7 +6,7 @@ const StopSearchHandler = C.StopSearchHandlerBase.extend({
 
   major_type: Stops.races,
 
-  types: [Stops.races],
+  types: [Stops.races, Stops.ethnicities],
 
   _pprint: (d) => Stops.pprint.get(d)
 });

--- a/traffic_stops/static/js/app/states/nc/Stops.js
+++ b/traffic_stops/static/js/app/states/nc/Stops.js
@@ -53,7 +53,7 @@ export const StopRatioTimeSeries = C.StopRatioTimeSeriesBase.extend({
 });
 
 export const StopsTable = C.StopsTableBase.extend({
-  types: [Stops.races],
+  types: [Stops.races, Stops.ethnicities],
 
   _get_header_rows: function () {
     return Stops.pprint.values();

--- a/traffic_stops/static/js/app/states/nc/defaults.js
+++ b/traffic_stops/static/js/app/states/nc/defaults.js
@@ -18,7 +18,9 @@ export default {
     'black': 'Black',
     'native_american': 'Native American',
     'asian': 'Asian',
-    'other': 'Other'
+    'other': 'Other',
+    'hispanic': 'Hispanic',
+    'non-hispanic': 'Non-hispanic'
   }),
   colors: [
     "#1C9647", // dark green

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -40,6 +40,7 @@
       <li><a href="#stop-percentage">Traffic Stops</a></li>
       <li><a href="#search-percentage-dept">{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Rate</a></li>
     </ul>
+    {% block race-selector %}{% endblock race-selector %}
   </div>
 </nav>
 


### PR DESCRIPTION
Previous work (#213) removed the race/ethnicity toggle from the `agency_detail.html` page, but it also removed ethnicity data from the charts. Since the ticket did not ask us to remove the ethnicity data from the charts, this pull request adds that data back onto the `agency_detail.html` page. Also, the `race-selector` block has been re-added to the base template, since the ticket only specified removing it from the NC pages.