### PR TITLE
TRH-2739-Fix-MD-Chart-Titles

### DIFF
--- a/md/templates/md/agency_detail.html
+++ b/md/templates/md/agency_detail.html
@@ -54,7 +54,7 @@
 
   <div class="row">
     <div class="col-md-12">
-      <h3>Traffic Stops</h3>
+      <h3>Traffic Stops (percentage by race)</h3>
 
       <p class="help-block">
         {% comment %}
@@ -231,7 +231,7 @@
 {% block search-display %}
   <div class="row">
     <div class="col-md-12">
-      <h3>Search Data by Race/Ethnicity</h3>
+      <h3>Search Data by Ethnicity</h3>
 
       <p class="help-block">
         {% comment %}


### PR DESCRIPTION
This PR does the following:
- Restore MD chart titles to those on Production
- Chart titles are the same on both departmental and officer pages.
- The only chart title that should’ve changed, as listed on the original ticket ([TRH-2625](https://caktus.atlassian.net/browse/TRH-2625)) under the second AC:

> The table currently named "Average Officer Search Rate For Vehicle Stops" is named "Officer Search Rate for Vehicle Stops" on these single-officer pages