### PR TITLE
[TRH-2626] Update MD Data

### DIFF
--- a/md/data/__init__.py
+++ b/md/data/__init__.py
@@ -1,1 +1,1 @@
-DEFAULT_URL = 'https://s3-us-west-2.amazonaws.com/openpolicingdata/MD_Traffic_Stops_through_20161003.zip'  # noqa
+DEFAULT_URL = 'https://s3-us-west-2.amazonaws.com/openpolicingdata/md/merged/MD_Traffic_Stops_through_20171231.zip'  # noqa

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -133,7 +133,7 @@
   <table class='table table-condensed table-hover'>
     <tr>
       <th>Timeframe</th>
-      <td>Jan 1 2013 - Dec312, 2017</td>
+      <td>Jan 1 2013 - Dec 31, 2017</td>
     </tr>
     <tr>
       <th>Stops</th>

--- a/md/templates/md.html
+++ b/md/templates/md.html
@@ -133,19 +133,19 @@
   <table class='table table-condensed table-hover'>
     <tr>
       <th>Timeframe</th>
-      <td>Jan 1 2013 - October 2, 2016</td>
+      <td>Jan 1 2013 - Dec312, 2017</td>
     </tr>
     <tr>
       <th>Stops</th>
-      <td>2,819,384</td>
+      <td>3,782,094</td>
     </tr>
     <tr>
       <th>Searches</th>
-      <td>83,820</td>
+      <td>113,961</td>
     </tr>
     <tr>
       <th>Agencies</th>
-      <td>127</td>
+      <td>131</td>
     </tr>
   </table>
 {% endblock dataset-facts %}


### PR DESCRIPTION
Updated link to new merged data set. Values updated from the output of `python manage.py analyze_md`:

```
Dataset facts

  Time frame: 2013-01-01 20:22:00 - 2017-12-31 23:59:00

  Stops: 3,782,094

  Searches: 113,961

  Agencies: 131



Top five agencies:

  Maryland State Police          1,092,912

  Montgomery County Police Department 387,551

  Baltimore County Police Department 351,616

  Maryland Transportation Authority Police 293,524

  Anne Arundel County Police Department 218,442
...
```