### PR TITLE
[ODPM-212] "Search Count" graph

### DIFF
--- a/nc/api.py
+++ b/nc/api.py
@@ -10,6 +10,7 @@ from rest_framework_extensions.key_constructor import bits
 from rest_framework_extensions.key_constructor.constructors import DefaultObjectKeyConstructor
 
 from nc.models import Agency, Stop
+from nc.models import SEARCH_TYPE_CHOICES as SEARCH_TYPE_CHOICES_TUPLES
 from nc import serializers
 from tsdata.utils import GroupedData
 
@@ -38,6 +39,8 @@ GROUP_DEFAULTS = {'asian': 0,
                   'other': 0,
                   'white': 0,
                   'hispanic': 0}
+
+SEARCH_TYPE_CHOICES = dict(SEARCH_TYPE_CHOICES_TUPLES)
 
 
 class QueryKeyConstructor(DefaultObjectKeyConstructor):
@@ -75,6 +78,12 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
                 purpose = PURPOSE_CHOICES.get(stop['purpose'],
                                               stop['purpose'])
                 data['purpose'] = purpose
+
+            if 'search__type' in group_by:
+                data['search_type'] = SEARCH_TYPE_CHOICES.get(
+                    stop['search__type'],
+                    stop['search__type'],
+                )
 
             if 'person__race' in group_by:
                 # The 'Hispanic' ethnicity option is now being aggreggated into its
@@ -126,6 +135,14 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
         results = GroupedData(by='year', defaults=GROUP_DEFAULTS)
         q = Q(search__isnull=False)
         self.query(results, group_by=('year', 'person__race', 'person__ethnicity'), filter_=q)
+        return Response(results.flatten())
+
+    @detail_route(methods=['get'])
+    @cache_response(key_func=query_cache_key_func)
+    def searches_by_type(self, request, pk=None):
+        results = GroupedData(by=('search_type', 'year'), defaults=GROUP_DEFAULTS)
+        q = Q(search__isnull=False)
+        self.query(results, group_by=('search__type', 'year', 'person__race', 'person__ethnicity'), filter_=q)
         return Response(results.flatten())
 
     @detail_route(methods=['get'])

--- a/nc/api.py
+++ b/nc/api.py
@@ -142,7 +142,16 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
     def searches_by_type(self, request, pk=None):
         results = GroupedData(by=('search_type', 'year'), defaults=GROUP_DEFAULTS)
         q = Q(search__isnull=False)
-        self.query(results, group_by=('search__type', 'year', 'person__race', 'person__ethnicity'), filter_=q)
+        self.query(
+            results,
+            group_by=(
+                'search__type',
+                'year',
+                'person__race',
+                'person__ethnicity',
+            ),
+            filter_=q,
+        )
         return Response(results.flatten())
 
     @detail_route(methods=['get'])

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -9,7 +9,14 @@ from django.test.client import Client
 from nc.models import Agency
 
 logger = logging.getLogger(__name__)
-ENDPOINTS = ('stops', 'stops_by_reason', 'use_of_force', 'searches', 'contraband_hit_rate')
+ENDPOINTS = (
+    'stops',
+    'stops_by_reason',
+    'use_of_force',
+    'searches',
+    'searches_by_type',
+    'contraband_hit_rate',
+)
 DEFAULT_CUTOFF_SECS = 4
 
 

--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -126,6 +126,47 @@
   </div>
 {% endblock stop-display %}
 
+{% block search-count-display %}
+<div class="row">
+  <div class="col-md-12">
+  <h3>{% if officer_id %}Officer{% else %}Departmental{% endif %} Search Count</h3>
+
+  <p class="help-block">
+    This graph displays the number of searches broken down by search
+    type and ethnicity. Adjusting the drop down menu will display the
+    individual search counts relative to ethnic groups on a year-by-year basis.
+  </p>
+</div>
+
+  <div class="col-md-10">
+    <div role="tabpanel">
+      <!-- Nav tabs -->
+      <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active">
+          <a href="#st_line_div" role="tab" data-toggle="tab">Chart</a></li>
+        <li role="presentation">
+          <a href="#st_data" role="tab" data-toggle="tab">Data</a></li>
+      </ul>
+
+      <!-- Tab panes -->
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active" id="st_line_div">
+          <svg id="st_line"></svg>
+        </div>
+        <div role="tabpanel" class="tab-pane" id="st_data">
+        </div>
+      </div>
+    </div>
+
+    <p class="graph-help-block">
+      Drag the cursor over the graph to see the racial breakdown for any
+      given year. Some percentages may be based on low levels of observation.
+      Click the “Data” tab to review the raw stop data.
+    </p>
+  </div>
+</div>
+{% endblock search-count-display %}
+
 {% block search-rate-display %}
   <div class="row">
     <div class="col-md-12 headline">
@@ -452,6 +493,7 @@ var showEthnicity = {{request.session.showEthnicity|lower|default:"false"}},
   // Retrieve data from API using data-handlers
   var stop_handler = new NC.StopsHandler({url: "{% url 'nc:agency-api-stops' object.pk %}?officer={{officer_id|urlencode}}"}),
       search_handler = new NC.SearchHandler({url: "{% url 'nc:agency-api-searches' object.pk %}?officer={{officer_id|urlencode}}"}),
+      searches_by_type_handler = new NC.STHandler({url: "{% url 'nc:agency-api-searches-by-type' object.pk %}?officer={{officer_id|urlencode}}"}),
       uf_handler = new NC.UseOfForceHandler({url: "{% url 'nc:agency-api-use-of-force' object.pk %}?officer={{officer_id|urlencode}}"}),
       lhs_handler = new NC.LikelihoodSearchHandler({url: "{% url 'nc:agency-api-stops-by-reason' object.pk %}?officer={{officer_id|urlencode}}"}),
       chr_handler = new NC.ContrabandHitRateHandler({url: "{% url 'nc:agency-api-contraband-hit-rate' object.pk %}?officer={{officer_id|urlencode}}"});
@@ -459,6 +501,7 @@ var showEthnicity = {{request.session.showEthnicity|lower|default:"false"}},
   // Retrieve data from API using data-handlers
   var stop_handler = new NC.StopsHandler({url: "{% url 'nc:agency-api-stops' object.pk %}"}),
       search_handler = new NC.SearchHandler({url: "{% url 'nc:agency-api-searches' object.pk %}"}),
+      searches_by_type_handler = new NC.STHandler({url: "{% url 'nc:agency-api-searches-by-type' object.pk %}"}),
       uf_handler = new NC.UseOfForceHandler({url: "{% url 'nc:agency-api-use-of-force' object.pk %}"}),
       lhs_handler = new NC.LikelihoodSearchHandler({url: "{% url 'nc:agency-api-stops-by-reason' object.pk %}"}),
       chr_handler = new NC.ContrabandHitRateHandler({url: "{% url 'nc:agency-api-contraband-hit-rate' object.pk %}"});
@@ -471,6 +514,9 @@ new NC.CensusTable({handler: census_handler, selector: "#census_data", showEthni
 new NC.StopRatioDonut({handler: stop_handler, selector: "#stop_race_pie", showEthnicity: showEthnicity});
 new NC.StopRatioTimeSeries({handler: stop_handler, selector: "#stop_race_line", showEthnicity: showEthnicity});
 new NC.StopsTable({handler: stop_handler, selector: "#stop_race_data", showEthnicity: showEthnicity});
+
+new NC.STTimeSeries({handler: searches_by_type_handler, selector: '#st_line', showEthnicity: showEthnicity});
+new NC.STTable({handler: searches_by_type_handler, selector: '#st_data', showEthnicity: showEthnicity});
 
 new NC.StopSearchTimeSeries({handler: stop_search_handler, selector: "#stop_search_line", showEthnicity: showEthnicity});
 new NC.StopSearchTable({handler: stop_search_handler, selector: "#stop_search_data", showEthnicity: showEthnicity});

--- a/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
+++ b/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
@@ -1,52 +1,10 @@
 import _ from 'underscore';
 import d3 from 'd3';
 
+import { get_years, get_totals } from '../util.js';
 import DataHandlerBase from '../base/DataHandlerBase.js';
 import VisualBase from '../base/VisualBase.js';
 import TableBase from '../base/TableBase.js';
-
-export function get_years (data, Stops) {
-  let years = d3.set(data.map((v) => v.year)).values();
-
-  years.filter((v) => (v >= Stops.start_year));
-  years.push("Total");
-
-  return years;
-}
-
-export function get_totals (a, types, reason_type) {
-  // calculate total for all years by purpose; push to array
-  let arr = _.clone(a);
-
-  var reasons = d3.nest()
-                   .key((d) => d[reason_type])
-                   .entries(arr);
-
-  reasons.forEach((v) => {
-    // create new totals object, and reset race/ethnicity-values
-    var total = _.clone(v.values[0]);
-
-    _.keys(total).forEach((key) => {
-      if (_.some(types, (t) => t.indexOf(key) >= 0)) {
-        total[key] = 0;
-      }
-    });
-
-    // sum data from all years
-    v.values.forEach((year) => {
-      _.keys(year).forEach((key) => {
-        if (_.some(types, (t) => t.indexOf(key) >= 0)) {
-          total[key] += year[key];
-        }
-      });
-    });
-
-    total["year"] = "Total";
-    arr.push(total);
-  });
-
-  return arr;
-}
 
 export const IRRHandlerBase = DataHandlerBase.extend({
   types: [], // abstract property, requires override

--- a/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
+++ b/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
@@ -1,11 +1,17 @@
 import _ from 'underscore';
 import d3 from 'd3';
 
-import { get_years, get_totals } from '../util.js';
+import { get_years, get_totals, toTitleCase } from '../util.js';
 import DataHandlerBase from '../base/DataHandlerBase.js';
 import VisualBase from '../base/VisualBase.js';
 import TableBase from '../base/TableBase.js';
 
+/*
+  NOTE: This should really be used by the StopByReasonAndRace graphs
+  instead of the LikelihoodOfSearch handler, but since that
+  would add an additional API hit, let's leave it for now.
+  For the time being it is used only in the SearchByType graphs.
+*/
 export const IRRHandlerBase = DataHandlerBase.extend({
   types: [], // abstract property, requires override
   defaults: {}, // abstract property, requires override
@@ -204,8 +210,8 @@ export const IRRTimeSeriesBase = VisualBase.extend({
       };
 
       var incidents = _.filter(
-        this._raw_data()
-      , (incident) => (String(incident.year) === year)
+        this._raw_data(),
+        (incident) => (String(incident.year) === year)
       );
 
       incidents.forEach((incident) => {
@@ -296,7 +302,7 @@ export const IRRTableBase = TableBase.extend({
 
     // create row with initial header row
     let rows = [
-      ["Year", this.incident_type.charAt(0).toUpperCase() + this.incident_type.slice(1) + "-reason", ...this._get_header_rows()]
+      ["Year", toTitleCase(this.incident_type) + "-reason", ...this._get_header_rows()]
     ];
 
     let reasons = this.Stops[this.reason_order_key].keys().filter(reason_filter);

--- a/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
+++ b/traffic_stops/static/js/app/common/LikelihoodOfSearch.js
@@ -1,3 +1,4 @@
+import { get_years, get_totals } from '../util.js';
 import DataHandlerBase from '../base/DataHandlerBase.js';
 import VisualBase from '../base/VisualBase.js';
 import TableBase from '../base/TableBase.js';
@@ -5,63 +6,20 @@ import d3 from 'd3';
 import _ from 'underscore';
 import $ from 'jquery';
 
-export function get_years (raw, Stops) {
-  let years = d3.set(raw.stops.map((v) => v.year)).values();
-
-  years.filter((v) => (v >= Stops.start_year));
-  years.push("Total");
-
-  return years;
-}
-
-export function get_totals (a, types) {
-  // calculate total for all years by purpose; push to array
-  let arr = _.clone(a);
-
-  var purposes = d3.nest()
-                   .key((d) => d.purpose)
-                   .entries(arr);
-
-  purposes.forEach((v) => {
-    // create new totals object, and reset race/ethnicity-values
-    var total = _.clone(v.values[0]);
-
-    _.keys(total).forEach((key) => {
-      if (_.some(types, (t) => t.indexOf(key) >= 0)) {
-        total[key] = 0;
-      }
-    });
-
-    // sum data from all years
-    v.values.forEach((year) => {
-      _.keys(year).forEach((key) => {
-        if (_.some(types, (t) => t.indexOf(key) >= 0)) {
-          total[key] += year[key];
-        }
-      });
-    });
-
-    total["year"] = "Total";
-    arr.push(total);
-  });
-
-  return arr;
-}
-
 export const LikelihoodSearchHandlerBase = DataHandlerBase.extend({
   types: [],
   defaults: {},
 
   clean_data: function () {
     let raw = this.get("raw_data");
-    let years = get_years(raw, this.Stops);
+    let years = get_years(raw.stops, this.Stops);
 
     if (raw.stops.length>0) {
-      raw.stops = get_totals(raw.stops, this.types);
+      raw.stops = get_totals(raw.stops, this.types, 'purpose');
     }
 
     if (raw.searches.length > 0 ) {
-      raw.searches = get_totals(raw.searches, this.types);
+      raw.searches = get_totals(raw.searches, this.types, 'purpose');
     }
 
     // set cleaned-data to handler

--- a/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
@@ -29,6 +29,7 @@ const SRRTable = C.IRRTableBase.extend({
   types: [Stops.ethnicities],
   incident_type: 'stop',
   incident_type_plural: 'stops',
+  reason_type: 'purpose',
   reason_order_key: 'purpose_order',
 
   Stops: Stops,

--- a/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
@@ -1,8 +1,10 @@
 import Stops from './defaults.js';
-import * as C from '../../common/StopByReasonAndRace.js';
+import * as C from '../../common/IncidentByReasonAndRace.js';
 
-export const SRRTimeSeries = C.SRRTimeSeriesBase.extend({
+export const SRRTimeSeries = C.IRRTimeSeriesBase.extend({
   Stops: Stops,
+  incident_type: 'stop',
+  incident_type_plural: 'stops',
 
   defaults: {
     width: 750,
@@ -15,16 +17,26 @@ export const SRRTimeSeries = C.SRRTimeSeriesBase.extend({
 
   _pprint: function (x) {
     return x;
+  },
+
+  _raw_data: function () {
+    return this.data.raw.stops;
   }
 });
 
-const SRRTable = C.SRRTableBase.extend({
+const SRRTable = C.IRRTableBase.extend({
   types: [Stops.ethnicities],
+  incident_type: 'stop',
+  incident_type_plural: 'stops',
 
   Stops: Stops,
 
   _get_header_rows: function () {
     return Stops.ethnicities
+  },
+
+  _raw_data: function () {
+    return this.data.raw.stops;
   }
 });
 

--- a/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
@@ -5,6 +5,7 @@ export const SRRTimeSeries = C.IRRTimeSeriesBase.extend({
   Stops: Stops,
   incident_type: 'stop',
   incident_type_plural: 'stops',
+  reason_type: 'purpose',
 
   defaults: {
     width: 750,
@@ -28,6 +29,7 @@ const SRRTable = C.IRRTableBase.extend({
   types: [Stops.ethnicities],
   incident_type: 'stop',
   incident_type_plural: 'stops',
+  reason_order_key: 'purpose_order',
 
   Stops: Stops,
 

--- a/traffic_stops/static/js/app/states/il/defaults.js
+++ b/traffic_stops/static/js/app/states/il/defaults.js
@@ -44,5 +44,5 @@ export default {
     'Equipment': 0,
     'Moving Violation': 1,
     'Registration': 2,
-  }),
+  })
 };

--- a/traffic_stops/static/js/app/states/md/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/md/StopByReasonAndRace.js
@@ -1,8 +1,10 @@
 import Stops from './defaults.js';
-import * as C from '../../common/StopByReasonAndRace.js';
+import * as C from '../../common/IncidentByReasonAndRace.js';
 
-export const SRRTimeSeries = C.SRRTimeSeriesBase.extend({
+export const SRRTimeSeries = C.IRRTimeSeriesBase.extend({
   Stops: Stops,
+  incident_type: 'stop',
+  incident_type_plural: 'stops',
 
   defaults: {
     width: 750,
@@ -15,16 +17,26 @@ export const SRRTimeSeries = C.SRRTimeSeriesBase.extend({
 
   _pprint: function (x) {
     return x;
+  },
+
+  _raw_data: function () {
+    return this.data.raw.stops;
   }
 });
 
-const SRRTable = C.SRRTableBase.extend({
+const SRRTable = C.IRRTableBase.extend({
   types: [Stops.ethnicities],
 
   Stops: Stops,
+  incident_type: 'stop',
+  incident_type_plural: 'stops',
 
   _get_header_rows: function () {
     return Stops.ethnicities
+  },
+
+  _raw_data: function () {
+    return this.data.raw.stops;
   }
 });
 

--- a/traffic_stops/static/js/app/states/md/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/md/StopByReasonAndRace.js
@@ -5,6 +5,7 @@ export const SRRTimeSeries = C.IRRTimeSeriesBase.extend({
   Stops: Stops,
   incident_type: 'stop',
   incident_type_plural: 'stops',
+  reason_type: 'purpose',
 
   defaults: {
     width: 750,
@@ -30,6 +31,8 @@ const SRRTable = C.IRRTableBase.extend({
   Stops: Stops,
   incident_type: 'stop',
   incident_type_plural: 'stops',
+  reason_type: 'purpose',
+  reason_order_key: 'purpose_order',
 
   _get_header_rows: function () {
     return Stops.ethnicities

--- a/traffic_stops/static/js/app/states/nc/SearchByType.js
+++ b/traffic_stops/static/js/app/states/nc/SearchByType.js
@@ -1,0 +1,69 @@
+import d3 from 'd3';
+
+import DataHandlerBase from '../../base/DataHandlerBase.js';
+import Stops from './defaults.js';
+import { StopsHandler } from './Stops.js';
+import * as C from '../../common/IncidentByReasonAndRace.js';
+
+export const STHandler = C.IRRHandlerBase.extend({
+  Stops: Stops,
+  types: [Stops.ethnicities],
+  reason_type: 'search_type'
+});
+
+export const STTimeSeries = C.IRRTimeSeriesBase.extend({
+  Stops: Stops,
+  incident_type: 'search',
+  incident_type_plural: 'searches',
+  reason_type: 'search_type',
+
+  defaults: {
+    width: 750,
+    height: 375,
+  },
+
+  _items: function () {
+    return Stops.ethnicities;
+  },
+
+  _pprint: function (x) {
+    return x;
+  },
+
+  _raw_data: function () {
+    return this.data.raw;
+  },
+
+  _pprint: function (type) {
+    return Stops.pprint.get(type);
+  }
+});
+
+const STTable = C.IRRTableBase.extend({
+  types: [Stops.ethnicities],
+
+  Stops: Stops,
+  incident_type: 'search',
+  incident_type_plural: 'searches',
+  reason_type: 'search_type',
+  reason_order_key: 'search_type_order',
+
+  _get_header_rows: function () {
+    return Stops.pprint.values();
+  },
+
+  _raw_data: function () {
+    return this.data.raw;
+  },
+
+  _pprint: function (type) {
+    return Stops.pprint.get(type);
+  }
+});
+
+
+export default {
+  STHandler,
+  STTimeSeries,
+  STTable
+};

--- a/traffic_stops/static/js/app/states/nc/defaults.js
+++ b/traffic_stops/static/js/app/states/nc/defaults.js
@@ -51,4 +51,11 @@ export default {
     'Seat Belt Violation': 8,
     'Checkpoint': 9  // todo: use a list and indexOf instead of map
   }),
+  search_type_order: d3.map({
+    'Consent': 0,
+    'Search Warrant': 1,
+    'Probable Cause': 2,
+    'Search Incident to Arrest': 3,
+    'Protective Frisk': 4
+  })
 };

--- a/traffic_stops/static/js/app/states/nc/index.js
+++ b/traffic_stops/static/js/app/states/nc/index.js
@@ -1,6 +1,7 @@
 import Stops from './defaults.js';
 import StopsGraphs from './Stops.js';
 import Search from './Search.js';
+import SearchByType from './SearchByType.js';
 import Census from './Census.js';
 import StopSearch from './StopSearch.js';
 import LikelihoodOfSearch from './LikelihoodOfSearch.js';
@@ -17,6 +18,7 @@ Object.assign(
   {Stops},
   StopsGraphs,
   Search,
+  SearchByType,
   Census,
   StopSearch,
   LikelihoodOfSearch,

--- a/traffic_stops/static/js/app/util.js
+++ b/traffic_stops/static/js/app/util.js
@@ -51,3 +51,7 @@ export function get_totals (a, types, reason_type) {
 
   return arr;
 }
+
+export function toTitleCase (str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/traffic_stops/static/js/app/util.js
+++ b/traffic_stops/static/js/app/util.js
@@ -1,0 +1,53 @@
+import _ from 'underscore';
+import d3 from 'd3';
+
+/*
+  Used by LikelihoodSearchHandlerBase and IRRHandlerBase
+  to create the years for the "Total" rows for the data table.
+*/
+export function get_years (data, Stops) {
+  let years = d3.set(data.map((v) => v.year)).values();
+
+  years.filter((v) => (v >= Stops.start_year));
+  years.push("Total");
+
+  return years;
+}
+
+/*
+  Used by LikelihoodSearchHandlerBase and IRRHandlerBase
+  to fill in the data for the "Total" rows for the data table.
+*/
+export function get_totals (a, types, reason_type) {
+  // calculate total for all years by purpose; push to array
+  let arr = _.clone(a);
+
+  var reasons = d3.nest()
+                   .key((d) => d[reason_type])
+                   .entries(arr);
+
+  reasons.forEach((v) => {
+    // create new totals object, and reset race/ethnicity-values
+    var total = _.clone(v.values[0]);
+
+    _.keys(total).forEach((key) => {
+      if (_.some(types, (t) => t.indexOf(key) >= 0)) {
+        total[key] = 0;
+      }
+    });
+
+    // sum data from all years
+    v.values.forEach((year) => {
+      _.keys(year).forEach((key) => {
+        if (_.some(types, (t) => t.indexOf(key) >= 0)) {
+          total[key] += year[key];
+        }
+      });
+    });
+
+    total["year"] = "Total";
+    arr.push(total);
+  });
+
+  return arr;
+}

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -52,6 +52,7 @@
       {% block census-display %}{% endblock census-display %}
       {% block stop-display %}{% endblock stop-display %}
       {% block stop-count-display %}{% endblock stop-count-display %}
+      {% block search-count-display %}{% endblock search-count-display %}
       {% block search-rate-display %}{% endblock search-rate-display %}
       {% block search-display %}{% endblock search-display %}
       {% block lsb-display %}{% endblock lsb-display %}


### PR DESCRIPTION
To let users view searches grouped by "type", this adds a new graph-table pair on the model of "Departmental Stop Count" and the API endpoint to support it.

The new API endpoint is a simple addition that slices the year-by-year search counts by type and adds the type to each object as `search__type`. This new endpoint is added to the cache-priming system.

The changes on the front-end are a little hairy because we want to reuse as much as possible from `StopByReasonAndRace` while respecting the differences between the data they consume. It wouldn't be cool to force the "search count" API endpoint to generate data with weird labels (`stops`, `purpose`, etc) for the historical reason that this graph was based on another one that consumed an API where those labels made sense. Hence we need to create generalized versions of the `StopByReasonAndRace` machinery that lets us define what part of the API's return value we're interested in, the name of the group-by key, the human-readable name of the values under discussion, etc.

The former `StopByReasonAndRace` module has been renamed `IncidentByReasonAndRace`, and the changes in that module all relate to changing hard-coded values to references to abstract properties specified on the subclasses. For example, the use of `this.data.raw.stops` is systematically replaced by `this._raw_data()`.

The new API handler, graph, and table are all defined as subclasses from the contents of `IncidentByReasonAndRace` and linked in by the usual means.