### PR TITLE
[ODPM-214] Using _.memoize in abstract classes causes weird problems

### DIFF
--- a/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
+++ b/traffic_stops/static/js/app/common/IncidentByReasonAndRace.js
@@ -115,18 +115,18 @@ export const IRRTimeSeriesBase = VisualBase.extend({
   },
 
   /***
-   * Pure function to return array of years present in dataset.
+   * Function to return array of years present in dataset.
    */
-  _years: _.memoize(function () {
+  _years: function () {
     var years_all = d3.set(_.pluck(this._raw_data(), 'year')).values();
     var years = _.without(years_all, 'Total');
     return years;
-  }),
+  },
 
   /***
-   * Pure function to return the dataset sorted by "type" and incident reason.
+   * Function to return the dataset sorted by "type" and incident reason.
    */
-  _getByReason: _.memoize(function (reason) {
+  _getByReason: function (reason) {
     var types = this._items();
     var years = this._years();
     var raw_data, data;
@@ -170,7 +170,7 @@ export const IRRTimeSeriesBase = VisualBase.extend({
     }));
 
     return this._checkThreshold(data);
-  }),
+  },
 
   /***
    * Helper function to identify data that should not be displayed on
@@ -195,11 +195,11 @@ export const IRRTimeSeriesBase = VisualBase.extend({
   },
 
   /***
-   * Pure function to create a virtual "All" reason data object for each year.
+   * Function to create a virtual "All" reason data object for each year.
    * Iterates through each year returned by _years and sums up the counts for
    * each race/ethnicity.
    */
-  _reasonAll: _.memoize(function () {
+  _reasonAll: function () {
     var data = [];
     var years = this._years();
 
@@ -233,7 +233,7 @@ export const IRRTimeSeriesBase = VisualBase.extend({
     });
 
     return data;
-  })
+  }
 });
 
 export const IRRTableBase = TableBase.extend({
@@ -251,9 +251,9 @@ export const IRRTableBase = TableBase.extend({
     this.add_select();
   },
 
-  _reasons: _.memoize(function () {
+  _reasons: function () {
     return d3.set(_.pluck(this._raw_data(), this.reason_type));
-  }),
+  },
 
   add_select: function () {
     let div = $(this.get("selector"));
@@ -261,7 +261,7 @@ export const IRRTableBase = TableBase.extend({
     // select input  only needs to be added once
     if (div.find('select').length) { return true; }
 
-    let $selector = $('<select id="srr-table-select">');
+    let $selector = $(`<select id="${this.get('selector').replace('#', '')}_select">`);
     let reasons = this._reasons();
     let $opts = [$('<option value="All">All</option>')].concat(
       reasons

--- a/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/il/StopByReasonAndRace.js
@@ -27,12 +27,12 @@ export const SRRTimeSeries = C.IRRTimeSeriesBase.extend({
 
 const SRRTable = C.IRRTableBase.extend({
   types: [Stops.ethnicities],
+
+  Stops: Stops,
   incident_type: 'stop',
   incident_type_plural: 'stops',
   reason_type: 'purpose',
   reason_order_key: 'purpose_order',
-
-  Stops: Stops,
 
   _get_header_rows: function () {
     return Stops.ethnicities

--- a/traffic_stops/static/js/app/states/nc/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/nc/StopByReasonAndRace.js
@@ -38,6 +38,10 @@ const SRRTable = C.IRRTableBase.extend({
     return Stops.ethnicities
   },
 
+  _pprint: function (type) {
+    return Stops.pprint.get(type);
+  },
+
   _raw_data: function () {
     return this.data.raw.stops;
   }

--- a/traffic_stops/static/js/app/states/nc/StopByReasonAndRace.js
+++ b/traffic_stops/static/js/app/states/nc/StopByReasonAndRace.js
@@ -35,7 +35,7 @@ const SRRTable = C.IRRTableBase.extend({
   reason_order_key: 'purpose_order',
 
   _get_header_rows: function () {
-    return Stops.ethnicities
+    return Stops.pprint.values();
   },
 
   _pprint: function (type) {


### PR DESCRIPTION
The problem we were seeing was the result of the fact that the abstract base class `IRRTableBase` was caching the return values of certain method calls. We didn't notice that this was a problem so long as there was only one graph / table that extended `IRRTableBase` per page, which is the case everywhere but NC. But once there are *multiple sublcasses* of `IRRTableBase` on the page, memoization produces the unexpected and weird-looking result that only the *first instantiation* of the subclass gets its data cached.

Solution: dump `_.memoize`. The performance gains here are minimal; we're not exactly working with "big data"!

Also, though I don't think it has any real effects, the `IRRTableBase` retained direct reference to the ID `#srr-table-select` when creating its `<select>`. This can and should be replaced with something specific to the table type.